### PR TITLE
Fix jaeger tests

### DIFF
--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -19,7 +19,6 @@ import { NodeTracerProvider } from '@opentelemetry/node';
 import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { B3Propagator, B3InjectEncoding } from '@opentelemetry/propagator-b3';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 
 import { EnvResourceDetector } from './resource';
 import { Options, _setDefaultOptions } from './options';
@@ -30,13 +29,13 @@ export function startTracing(opts: Partial<Options> = {}): void {
     return;
   }
 
-  propagation.setGlobalPropagator(
-    new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER })
-  );
-
   const options = _setDefaultOptions(opts);
 
   _patchJaeger(options.maxAttrLength);
+
+  propagation.setGlobalPropagator(
+    new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER })
+  );
 
   const provider = new NodeTracerProvider({
     resource: new EnvResourceDetector().detect(),
@@ -44,7 +43,7 @@ export function startTracing(opts: Partial<Options> = {}): void {
 
   registerInstrumentations({ tracerProvider: provider });
 
-  provider.register({ contextManager: new AsyncHooksContextManager() });
+  provider.register();
 
   const jaegerOptions = {
     serviceName: options.serviceName!,


### PR DESCRIPTION

    Fixed jaeger test and removed explicit context manager registration

    - Now we don't setup entire tracing pipeline just to test jaeger
    exporter behaviour. We setup a simple provider and processor just to
    test jaeger. It does not have any side-effects on other tests.
    - We don't register any content manager anymore. NodeTracerProvider
    internally register the appropriate context manager automatically
    depending on the NodeJS version being used.