### PR TITLE
Cleaner import and instrument paths by removing `lib` from them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ You can find a list of instrumentation packages supported out of the box [here](
 You can also install additional packages and use them as described [here](#custom-instrumentation-packages).
 
 
-3. Run node app with `-r @splunk/otel/lib/instrument` CLI argument
+3. Run node app with `-r @splunk/otel/instrument` CLI argument
 
 ```
 export SPLK_SERVICE_NAME=my-node-svc
-node -r @splunk/otel/lib/instrument app.js
+node -r @splunk/otel/instrument app.js
 ```
 
 You can also instrument your app with code as described [here](#instrument-with-code).
@@ -113,7 +113,7 @@ In order to send traces directly to SignalFx ingest API, you need to:
 ## Automatically instrument an application
 
 You can use node's `-r` CLI flag to pre-load the instrumentation module and automatically instrument your NodeJS application.
-You can add `-r @splunk/otel/lib/instrument` CLI parameter to automatically instrument your application. 
+You can add `-r @splunk/otel/instrument` CLI parameter to automatically instrument your application. 
 
 For example, if you start your application as follows:
 
@@ -124,7 +124,7 @@ node index.js
 Then you can automatically instrument your application by running
 
 ```bash
-node -r @splunk/otel/lib/instrument index.js
+node -r @splunk/otel/instrument index.js
 ```
 
 
@@ -173,7 +173,7 @@ startTracing({
 ## Default Instrumentation Packages <a name="default-instrumentation-packages"></a>
 
 By default the following instrumentations will automatically be enabled if they are installed. In order to use
-any of these instrumentations, you'll need to install them with npm and then run your app with `-r @splunk/otel/lib/instrument`
+any of these instrumentations, you'll need to install them with npm and then run your app with `-r @splunk/otel/instrument`
 flag as described above.
 
 ```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const all = require('./lib/index');
+
+module.exports = all;

--- a/instrument.js
+++ b/instrument.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const all = require('./lib/instrument');
+
+module.exports = all;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "node": ">=8.0.0"
   },
   "files": [
+    "index.js",
+    "instrument.js",
+    "bin/*.js",
     "lib/**/*.js",
     "lib/**/*.js.map",
     "lib/**/*.d.ts",


### PR DESCRIPTION
We compile TS code from `src/` to `lib/`. Given how NPM works, this
means import paths must start with `@splunk/otel/lib`. All users have
to use this import path when importing code in their modules or when
instrumenting their apps from the command line with `-r
@splunk/otel/lib`.

This adds a couple of entry point JS files (index.js and instrument.js) that
just act as proxies for the real files. All they do is import everything
that the real files export and re-export them. This'll allow users to
instrument their apps with `-r @splunk/otel/instrument` and import
public members from `@splunk/otel`.