### PR TITLE
More and better instrumentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@
   at the same time.
 - `startTracing()` options now accepts a `propagatorFactory` option which can be
   used configure custom text map propagator.
+- Listed instrumentations as (optional) peer dependencies. This makes
+require()'ing instrumentations safer despite @splunk/otel not listing
+them as dependencies. Marking them optional ensures npm7 will not
+automatically install these packages. Note that this will still result
+in warnings for users on npm <7.
+- Added suport for the following instrumentations out of the box:
+  - @opentelemetry/instrumentation-express
+  - @opentelemetry/instrumentation-ioredis
+  - @opentelemetry/instrumentation-mongodb
+  - @opentelemetry/instrumentation-mysql
+  - @opentelemetry/instrumentation-net
+  - @opentelemetry/instrumentation-pg
+  - @opentelemetry/instrumentation-hapi
+- Removed support for the following instrumentations:
+  - @opentelemetry/hapi-instrumentation
 
 ## 0.4.0 (03-12-2021)
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ npm install @splunk/otel --save
 npm install @opentelemetry/instrumentation-http --save
 ```
 
+Note: If you are using NPM 6 or older, it'll warn you about missing peer dependencies. All of these dependencies are instrumentation packages and are completely optional. You can install the ones you need and ignore the rest. NPM 7+ supports optional peer dependencies feature and will not complain about this.
+
 You can find a list of instrumentation packages supported out of the box [here](#default-instrumentation-packages).
 
 You can also install additional packages and use them as described [here](#custom-instrumentation-packages).
@@ -197,8 +199,7 @@ startTracing({
 ## Default Instrumentation Packages <a name="default-instrumentation-packages"></a>
 
 By default the following instrumentations will automatically be enabled if they are installed. In order to use
-any of these instrumentations, you'll need to install them with npm and then run your app with `-r @splunk/otel/instrument`
-flag as described above.
+any of these instrumentations, you'll need to install them with npm and then run your app with `-r @splunk/otel/instrument` flag as described above.
 
 ```
 @opentelemetry/instrumentation-http
@@ -206,7 +207,13 @@ flag as described above.
 @opentelemetry/instrumentation-graphql
 @opentelemetry/instrumentation-grpc
 @opentelemetry/instrumentation-koa
-@opentelemetry/hapi-instrumentation
+@opentelemetry/instrumentation-express
+@opentelemetry/instrumentation-ioredis
+@opentelemetry/instrumentation-mongodb
+@opentelemetry/instrumentation-mysql
+@opentelemetry/instrumentation-net
+@opentelemetry/instrumentation-pg
+@opentelemetry/instrumentation-hapi
 ```
 
 You can find more instrumentation packages over at the [OpenTelemetry Registry](https://opentelemetry.io/registry/?language=js) and enable them manually 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,62 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/instrumentation-dns": "^0.14.0",
+        "@opentelemetry/instrumentation-express": "^0.14.0",
+        "@opentelemetry/instrumentation-graphql": "^0.14.0",
+        "@opentelemetry/instrumentation-grpc": "^0.18.0",
+        "@opentelemetry/instrumentation-hapi": "^0.14.0",
+        "@opentelemetry/instrumentation-http": "^0.18.0",
+        "@opentelemetry/instrumentation-ioredis": "^0.14.0",
+        "@opentelemetry/instrumentation-koa": "^0.14.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.14.0",
+        "@opentelemetry/instrumentation-mysql": "^0.14.0",
+        "@opentelemetry/instrumentation-net": "^0.14.0",
+        "@opentelemetry/instrumentation-pg": "^0.14.0",
+        "@opentelemetry/instrumentation-redis": "^0.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/instrumentation-dns": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation-express": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation-graphql": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation-grpc": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation-hapi": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation-ioredis": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation-koa": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation-mongodb": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation-mysql": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation-net": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation-pg": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation-redis": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -81,5 +81,61 @@
     "@opentelemetry/tracing": "^0.18.0",
     "jaeger-client": "^3.15.0",
     "semver": "^7.1.3"
+  },
+  "peerDependencies": {
+    "@opentelemetry/instrumentation-dns": "^0.14.0",
+    "@opentelemetry/instrumentation-express": "^0.14.0",
+    "@opentelemetry/instrumentation-graphql": "^0.14.0",
+    "@opentelemetry/instrumentation-grpc": "^0.18.0",
+    "@opentelemetry/instrumentation-hapi": "^0.14.0",
+    "@opentelemetry/instrumentation-http": "^0.18.0",
+    "@opentelemetry/instrumentation-ioredis": "^0.14.0",
+    "@opentelemetry/instrumentation-koa": "^0.14.0",
+    "@opentelemetry/instrumentation-mongodb": "^0.14.0",
+    "@opentelemetry/instrumentation-mysql": "^0.14.0",
+    "@opentelemetry/instrumentation-net": "^0.14.0",
+    "@opentelemetry/instrumentation-pg": "^0.14.0",
+    "@opentelemetry/instrumentation-redis": "^0.14.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/instrumentation-http": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-dns": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-graphql": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-grpc": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-koa": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-express": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-ioredis": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-mongodb": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-mysql": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-net": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-pg": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-redis": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-hapi": {
+      "optional": true
+    }
   }
 }

--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -24,7 +24,13 @@ const supportedInstrumentations: [string, string][] = [
   ['@opentelemetry/instrumentation-graphql', 'GraphQLInstrumentation'],
   ['@opentelemetry/instrumentation-grpc', 'GrpcInstrumentation'],
   ['@opentelemetry/instrumentation-koa', 'KoaInstrumentation'],
-  ['@opentelemetry/hapi-instrumentation', 'HapiInstrumentation'],
+  ['@opentelemetry/instrumentation-express', 'ExpressInstrumentation'],
+  ['@opentelemetry/instrumentation-ioredis', 'IORedisInstrumentation'],
+  ['@opentelemetry/instrumentation-mongodb', 'MongoDBInstrumentation'],
+  ['@opentelemetry/instrumentation-mysql', 'MySQLInstrumentation'],
+  ['@opentelemetry/instrumentation-net', 'NetInstrumentation'],
+  ['@opentelemetry/instrumentation-pg', 'PgInstrumentation'],
+  ['@opentelemetry/instrumentation-hapi', 'HapiInstrumentation'],
 ];
 
 export function getInstrumentations(): InstrumentationOption[] {

--- a/src/instrumentations/loader.ts
+++ b/src/instrumentations/loader.ts
@@ -28,7 +28,7 @@ export function load(
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     return require(module)[instrumentation];
   } catch (e) {
-    diag.info('cannot find instrumentation package: ' + instrumentation);
+    diag.debug('cannot find instrumentation package: ' + instrumentation);
   }
   return null;
 }

--- a/test/instrumentations.test.ts
+++ b/test/instrumentations.test.ts
@@ -22,6 +22,21 @@ import * as instrumentations from '../src/instrumentations';
 import * as loader from '../src/instrumentations/loader';
 
 describe('instrumentations', () => {
+  const supportedInstrumentations = [
+    ['@opentelemetry/instrumentation-http', 'HttpInstrumentation'],
+    ['@opentelemetry/instrumentation-dns', 'DnsInstrumentation'],
+    ['@opentelemetry/instrumentation-graphql', 'GraphQLInstrumentation'],
+    ['@opentelemetry/instrumentation-grpc', 'GrpcInstrumentation'],
+    ['@opentelemetry/instrumentation-koa', 'KoaInstrumentation'],
+    ['@opentelemetry/instrumentation-express', 'ExpressInstrumentation'],
+    ['@opentelemetry/instrumentation-ioredis', 'IORedisInstrumentation'],
+    ['@opentelemetry/instrumentation-mongodb', 'MongoDBInstrumentation'],
+    ['@opentelemetry/instrumentation-mysql', 'MySQLInstrumentation'],
+    ['@opentelemetry/instrumentation-net', 'NetInstrumentation'],
+    ['@opentelemetry/instrumentation-pg', 'PgInstrumentation'],
+    ['@opentelemetry/instrumentation-hapi', 'HapiInstrumentation'],
+  ];
+
   it('does not load if packages are not installed', () => {
     const inst = instrumentations.getInstrumentations();
     assert.strictEqual(inst.length, 0);
@@ -30,37 +45,14 @@ describe('instrumentations', () => {
   it('load instrumentations if they are not installed', () => {
     const loadStub = sinon.stub(loader, 'load');
     const inst = instrumentations.getInstrumentations();
-    sinon.assert.callCount(loadStub, 6);
-    sinon.assert.calledWith(
-      loader.load,
-      '@opentelemetry/instrumentation-http',
-      'HttpInstrumentation'
-    );
-    sinon.assert.calledWith(
-      loader.load,
-      '@opentelemetry/instrumentation-dns',
-      'DnsInstrumentation'
-    );
-    sinon.assert.calledWith(
-      loader.load,
-      '@opentelemetry/instrumentation-graphql',
-      'GraphQLInstrumentation'
-    );
-    sinon.assert.calledWith(
-      loader.load,
-      '@opentelemetry/instrumentation-grpc',
-      'GrpcInstrumentation'
-    );
-    sinon.assert.calledWith(
-      loader.load,
-      '@opentelemetry/instrumentation-koa',
-      'KoaInstrumentation'
-    );
-    sinon.assert.calledWith(
-      loader.load,
-      '@opentelemetry/hapi-instrumentation',
-      'HapiInstrumentation'
-    );
+    sinon.assert.callCount(loadStub, supportedInstrumentations.length);
+    for (let i = 0; i < supportedInstrumentations.length; i++) {
+      sinon.assert.calledWith(
+        loader.load,
+        supportedInstrumentations[i][0],
+        supportedInstrumentations[i][1]
+      );
+    }
 
     loadStub.reset();
     loadStub.restore();


### PR DESCRIPTION


# Description


- Listed instrumentations as (optional) peer dependencies. This makes
require()'ing instrumentations safer despite @splunk/otel not listing
them as dependencies. Marking them optional ensures npm7 will not
automatically install these packages. Note that this will still result
in warnings for users on npm <7.
- Added suport for the following instrumentations out of the box:
  - @opentelemetry/instrumentation-express
  - @opentelemetry/instrumentation-ioredis
  - @opentelemetry/instrumentation-mongodb
  - @opentelemetry/instrumentation-mysql
  - @opentelemetry/instrumentation-net
  - @opentelemetry/instrumentation-pg
  - @opentelemetry/instrumentation-hapi
- Removed support for the following instrumentations:
  - @opentelemetry/hapi-instrumentation


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested manually
- [x] Added automated tests

# Checklist:

- [x] Changelogs have been updated
- [x] Unit tests have been added/updated
- [x] Documentation has been updated
