### PR TITLE
Fix context manager for older node versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changed
+
+- Context management should not work properly on older versions of NodeJS (<14.8).
+  ([#53](https://github.com/signalfx/splunk-otel-js/pull/53))
+
+
 ## 0.5.0 (03-24-2021)
 
 - Replaced `SPLUNK_TRACE_EXPORTER_URL` with `OTEL_EXPORTER_JAEGER_ENDPOINT`.

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -42,7 +42,9 @@ export function startTracing(opts: Partial<Options> = {}): void {
   const ContextManager = gte(process.version, '14.8.0')
     ? AsyncLocalStorageContextManager
     : AsyncHooksContextManager;
-  context.setGlobalContextManager(new ContextManager());
+  const contextManager = new ContextManager();
+  contextManager.enable();
+  context.setGlobalContextManager(contextManager);
 
   // tracer provider
   const provider = new NodeTracerProvider(options.tracerConfig);


### PR DESCRIPTION
# Description

Async hooks context manager needs to be activated by calling `.enable()`
before it can be used as a context manager. This is important for older
versions of node that don't use support local storage context manager.

We need to release this as a hot fix. Will follow up with a test case to catch any regressions in future.

fixes #50