### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.9.0 (07-02-2021)
+
 - Add support for injecting trace context into logs.
   ([#121](https://github.com/signalfx/splunk-otel-js/pull/121))
 - Rename `SPLUNK_CONTEXT_SERVER_TIMING_ENABLED`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '0.8.0';
+export const VERSION = '0.9.0';


### PR DESCRIPTION
* Add support for injecting trace context into logs.
* Rename `SPLUNK_CONTEXT_SERVER_TIMING_ENABLED`
* Upgrade to OpenTelemetry SDK 0.22.0, API 1.0.0.
