### PR TITLE
Fix npm publish command

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,5 +54,5 @@ release:
     - mv splunk-otel-${CI_COMMIT_REF_NAME:1}.tgz dist/
     - shasum -a 256 dist/* > dist/checksums.txt
     - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-    - npm publish dist/splunk-otel-${CI_COMMIT_REF_NAME:1}.tgz
+    - npm publish ./dist/splunk-otel-${CI_COMMIT_REF_NAME:1}.tgz
     - rm -f ~/.npmrc


### PR DESCRIPTION
npm publish was assuming `dist/splunk-otel-{version}.tgz` was a git repo
and tried to check it out when publishing which obviously failed.

Change it to a relative path tells npm to look for the file on disk
rather than github.
