### PR TITLE
chore: deprecate SPLUNK_SERVICE_NAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Rename `SPLUNK_SERVICE_NAME` to `OTEL_SERVICE_NAME`
+
 ## 0.9.0 (07-02-2021)
 
 - Add support for injecting trace context into logs.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can also install additional packages and use them as described [here](#custo
 3. Run node app with `-r @splunk/otel/instrument` CLI argument
 
 ```
-export SPLUNK_SERVICE_NAME=my-node-svc
+export OTEL_SERVICE_NAME=my-node-svc
 node -r @splunk/otel/instrument app.js
 ```
 
@@ -69,7 +69,7 @@ You can also instrument your app with code as described [here](#instrument-with-
 | Environment variable                 | Config Option                 | Default value                        | Notes                                                                                                                                                            |
 | -----------------------------        | ----------------------------- | ------------------------------------ | ----------------------------------------------------------------------                                                                                           |
 | OTEL_EXPORTER_JAEGER_ENDPOINT        | endpoint                      | `http://localhost:9080/v1/trace`     | The jaeger endpoint to connect to. Currently only HTTP is supported.                                                                                             |
-| SPLUNK_SERVICE_NAME                  | serviceName                   | `unnamed-node-service`               | The service name of this Node service.                                                                                                                           |
+| OTEL_SERVICE_NAME                  | serviceName                   | `unnamed-node-service`               | The service name of this Node service.                                                                                                                           |
 | SPLUNK_ACCESS_TOKEN                  | acceessToken                  |                                      |                                                                                                                                                                  | The optional organization access token for trace submission requests. |
 | SPLUNK_MAX_ATTR_LENGTH               | maxAttrLength                 | 1200                                 | Maximum length of string attribute value in characters. Longer values are truncated.                                                                             |
 | SPLUNK_TRACE_RESPONSE_HEADER_ENABLED | serverTimingEnabled           | true                                 | Enable injection of `Server-Timing` header to HTTP responses.                                                                                                    |
@@ -149,13 +149,18 @@ startTracing({
   serviceName: 'my-node-service',
 });
 ```
+
+Please note that `startTracing` is destructive to Open Telemetry API globals. We provide the `stopTracing` method, but
+it won't revert to OTel API globals set before `startTracing` was run, it will only disable globals, which
+`startTracing` set.
+
 ### All config options <a name="config-options"></a>
 
 `startTracing()` accepts an optional argument to pass down configuration. The argument must be an Object and may contain any of the following keys.
 
 - `endpoint`: corresponds to the `OTEL_EXPORTER_JAEGER_ENDPOINT` environment variable. Defaults to `http://localhost:9080/v1/trace`. Configures the http endpoint to which all spans will be exported.
 
-- `serviceName`: corresponds to the `SPLUNK_SERVICE_NAME` environment variable. Defaults to `unnamed-node-service`. Configures the service name of the instrumented node service. The name is added to all spans as an attribute.
+- `serviceName`: corresponds to the `OTEL_SERVICE_NAME` environment variable. Defaults to `unnamed-node-service`. Configures the service name of the instrumented node service. The name is added to all spans as an attribute.
 
 - `accessToken`: corresponds to the `SPLUNK_ACCESS_TOKEN` environment variable. Configures the access token that should be used to authenticate with the span exporter http endpoint. Used when exporting directly to Splunk APM from a Node service.
 

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { TextMapGetter, TextMapPropagator } from '@opentelemetry/api';
+import { TextMapPropagator } from '@opentelemetry/api';
 import { HttpBaggage } from '@opentelemetry/core';
 import { InstrumentationBase } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -16,7 +16,6 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import * as URL from 'url';
 import {
   BatchSpanProcessor,
   SimpleSpanProcessor,
@@ -26,7 +25,7 @@ import {
 import { NodeTracerProvider } from '@opentelemetry/node';
 import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
 
-import { startTracing } from '../src/tracing';
+import { startTracing, stopTracing } from '../src/tracing';
 import * as jaeger from '../src/jaeger';
 
 describe('tracing', () => {
@@ -83,6 +82,7 @@ describe('tracing', () => {
     startTracing();
     sinon.assert.notCalled(addSpanProcessorMock);
     delete process.env.OTEL_TRACE_ENABLED;
+    stopTracing();
   });
 
   it('setups tracing with defaults', () => {
@@ -94,6 +94,7 @@ describe('tracing', () => {
       1200,
       false
     );
+    stopTracing();
   });
 
   it('setups tracing with custom options', () => {
@@ -116,6 +117,7 @@ describe('tracing', () => {
       maxAttrLength,
       logInjectionEnabled
     );
+    stopTracing();
   });
 
   it('setups tracing with custom options from env', () => {
@@ -126,15 +128,16 @@ describe('tracing', () => {
     const logInjectionEnabled = true;
 
     process.env.OTEL_EXPORTER_JAEGER_ENDPOINT = '';
-    process.env.SPLUNK_SERVICE_NAME = '';
+    process.env.OTEL_SERVICE_NAME = '';
     process.env.SPLUNK_ACCESS_TOKEN = '';
     process.env.SPLUNK_MAX_ATTR_LENGTH = '42';
     process.env.SPLUNK_LOGS_INJECTION = 'true';
+
     const envExporterStub = sinon
       .stub(process.env, 'OTEL_EXPORTER_JAEGER_ENDPOINT')
       .value(url);
     const envServiceStub = sinon
-      .stub(process.env, 'SPLUNK_SERVICE_NAME')
+      .stub(process.env, 'OTEL_SERVICE_NAME')
       .value(serviceName);
     const envAccessStub = sinon
       .stub(process.env, 'SPLUNK_ACCESS_TOKEN')
@@ -154,6 +157,8 @@ describe('tracing', () => {
       maxAttrLength,
       logInjectionEnabled
     );
+    stopTracing();
+
     envExporterStub.restore();
     envServiceStub.restore();
     envAccessStub.restore();
@@ -182,5 +187,7 @@ describe('tracing', () => {
     assert(p2 instanceof BatchSpanProcessor);
     const exp2 = p2['_exporter'];
     assert(exp2 instanceof InMemorySpanExporter);
+
+    stopTracing();
   });
 });


### PR DESCRIPTION
Use OTel's `OTEL_SERVICE_NAME` instead of `SPLUNK_SERVICE_NAME`

# Description

Correcting this unnecessary divergence from the standard.

Also, needed for smoother migration process (#168)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested manually
- [x] Added automated tests

# Checklist:

- [x] Changelogs have been updated
- [x] Unit tests have been added/updated
- [x] Documentation has been updated
