### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
+## 0.10.0 (07-09-2021)
+
 - Rename `SPLUNK_SERVICE_NAME` to `OTEL_SERVICE_NAME`
+  ([#170](https://github.com/signalfx/splunk-otel-js/pull/170))
+- Upgrade to OpenTelemetry SDK 0.23.0
+  ([#173](https://github.com/signalfx/splunk-otel-js/pull/173))
 
 ## 0.9.0 (07-02-2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '0.9.0';
+export const VERSION = '0.10.0';


### PR DESCRIPTION
- Rename `SPLUNK_SERVICE_NAME` to `OTEL_SERVICE_NAME`          
  ([#170](https://github.com/signalfx/splunk-otel-js/pull/170))
- Upgrade to OpenTelemetry SDK 0.23.0                          
  ([#173](https://github.com/signalfx/splunk-otel-js/pull/173))