### PR TITLE
test: catch errors from propagation test

### DIFF
--- a/test/propagation.test.ts
+++ b/test/propagation.test.ts
@@ -74,7 +74,7 @@ describe('propagation', () => {
     stopTracing();
   });
 
-  it('must attach synthetic run id to exported spans', done => {
+  it('must attach synthetic run id to exported spans', async () => {
     const exporter = new InMemorySpanExporter();
     let spanProcessor: SpanProcessor;
     startTracing({
@@ -94,18 +94,14 @@ describe('propagation', () => {
     const newContext = propagation.extract(context.active(), incomingCarrier);
     tracer.startSpan('request handler', {}, newContext).end();
 
-    spanProcessor
-      .forceFlush()
-      .then(() => {
-        assert.strictEqual(exporter.getFinishedSpans().length, 1);
-        assert.strictEqual(
-          exporter.getFinishedSpans()[0].attributes[SYNTHETIC_RUN_ID_FIELD],
-          syntheticsTraceId
-        );
+    await spanProcessor.forceFlush();
 
-        stopTracing();
-        done();
-      })
-      .catch(done);
+    assert.strictEqual(exporter.getFinishedSpans().length, 1);
+    assert.strictEqual(
+      exporter.getFinishedSpans()[0].attributes[SYNTHETIC_RUN_ID_FIELD],
+      syntheticsTraceId
+    );
+
+    stopTracing();
   });
 });

--- a/test/propagation.test.ts
+++ b/test/propagation.test.ts
@@ -31,6 +31,7 @@ import { defaultSpanProcessorFactory } from '../src/options';
 describe('propagation', () => {
   it('must be set to b3', () => {
     startTracing();
+
     assert(propagation.fields().includes('x-b3-traceid'));
     assert(propagation.fields().includes('x-b3-spanid'));
     assert(propagation.fields().includes('x-b3-sampled'));
@@ -38,18 +39,21 @@ describe('propagation', () => {
 
     const tracer = trace.getTracer('test-tracer');
     const span = tracer.startSpan('main');
+
+    const carrier = {};
+
     context.with(trace.setSpan(context.active(), span), () => {
-      const carrier = {};
       propagation.inject(context.active(), carrier, defaultTextMapSetter);
       span.end();
-
-      const traceId = span.spanContext().traceId;
-      const spanId = span.spanContext().spanId;
-      assert.strictEqual(carrier['x-b3-traceid'], traceId);
-      assert.strictEqual(carrier['x-b3-spanid'], spanId);
-      assert.strictEqual(carrier['x-b3-sampled'], '1');
-      assert.strictEqual(carrier['traceparent'], `00-${traceId}-${spanId}-01`);
     });
+
+    const traceId = span.spanContext().traceId;
+    const spanId = span.spanContext().spanId;
+    assert.strictEqual(carrier['x-b3-traceid'], traceId);
+    assert.strictEqual(carrier['x-b3-spanid'], spanId);
+    assert.strictEqual(carrier['x-b3-sampled'], '1');
+    assert.strictEqual(carrier['traceparent'], `00-${traceId}-${spanId}-01`);
+
     stopTracing();
   });
 


### PR DESCRIPTION
# Description

One of the propagation tests would just time out if any of the assertions would fail.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Internal change (a change which is not visible to the package consumers)
- [ ] Documentation change or requires a documentation update

# How Has This Been Tested?

- [ ] Tested manually
- [x] Added automated tests

# Checklist:

- [x] Unit tests have been added/updated
- [ ] Documentation has been updated
- [ ] Change file has been generated (`npm run change:new`)
