### PR TITLE
test: protect from environment leaking between tests

### DIFF
--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -37,8 +37,11 @@ import {
   Options,
   defaultPropagatorFactory,
 } from '../src/options';
+import * as utils from './utils';
 
 describe('options', () => {
+  beforeEach(utils.cleanEnvironment);
+
   it('verify default options', () => {
     // Mock the default `getInstrumentations` in case some instrumentations (e.g. http) are part of dev dependencies.
     const getInstrumentationsStub = sinon

--- a/test/resource.test.ts
+++ b/test/resource.test.ts
@@ -19,19 +19,12 @@ import * as sinon from 'sinon';
 
 import * as otel from '@opentelemetry/api';
 import { EnvResourceDetector } from '../src/resource';
+import * as utils from './utils';
 
 describe('resource detector', () => {
-  let envStub;
-
   beforeEach(() => {
+    utils.cleanEnvironment();
     process.env.OTEL_RESOURCE_ATTRIBUTES = '';
-  });
-
-  afterEach(() => {
-    if (envStub) {
-      envStub.restore();
-    }
-    delete process.env.OTEL_RESOURCE_ATTRIBUTES;
   });
 
   it('ignores missing attributes', () => {
@@ -40,29 +33,26 @@ describe('resource detector', () => {
   });
 
   it('ignores wrongly formatted env string', () => {
-    envStub = sinon
-      .stub(process.env, 'OTEL_RESOURCE_ATTRIBUTES')
-      .value('kkkkkkkkkkk');
+    process.env.OTEL_RESOURCE_ATTRIBUTES = 'kkkkkkkkkkk';
     const resource = new EnvResourceDetector().detect();
     assert.deepStrictEqual(resource.attributes, {});
   });
 
   it('ignores missing attr keys', () => {
-    envStub = sinon.stub(process.env, 'OTEL_RESOURCE_ATTRIBUTES').value('=v');
+    process.env.OTEL_RESOURCE_ATTRIBUTES = '=v';
     const resource = new EnvResourceDetector().detect();
     assert.deepStrictEqual(resource.attributes, {});
   });
 
   it('ignores unsupported value chars', () => {
-    envStub = sinon.stub(process.env, 'OTEL_RESOURCE_ATTRIBUTES').value('k2=␟');
+    process.env.OTEL_RESOURCE_ATTRIBUTES = 'k2=␟';
     const resource = new EnvResourceDetector().detect();
     assert.deepStrictEqual(resource.attributes, {});
   });
 
   it('parses properly formatted attributes', () => {
-    envStub = sinon
-      .stub(process.env, 'OTEL_RESOURCE_ATTRIBUTES')
-      .value('k=v,key1=val1,service.name=node-svc');
+    process.env.OTEL_RESOURCE_ATTRIBUTES =
+      'k=v,key1=val1,service.name=node-svc';
     const resource = new EnvResourceDetector().detect();
     assert.deepStrictEqual(resource.attributes, {
       k: 'v',

--- a/test/resource.test.ts
+++ b/test/resource.test.ts
@@ -24,7 +24,6 @@ import * as utils from './utils';
 describe('resource detector', () => {
   beforeEach(() => {
     utils.cleanEnvironment();
-    process.env.OTEL_RESOURCE_ATTRIBUTES = '';
   });
 
   it('ignores missing attributes', () => {

--- a/test/servertiming.test.ts
+++ b/test/servertiming.test.ts
@@ -19,6 +19,7 @@ import * as sinon from 'sinon';
 import { context, trace } from '@opentelemetry/api';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { startTracing } from '../src/tracing';
+import * as utils from './utils';
 
 const PORT = 9111;
 const SERVER_URL = `http://localhost:${PORT}`;
@@ -38,6 +39,7 @@ function assertHeaders(spanContext, response) {
 describe('servertiming', () => {
   let server;
 
+  beforeEach(utils.cleanEnvironment);
   afterEach(() => {
     server.close();
   });
@@ -62,13 +64,9 @@ describe('servertiming', () => {
   });
 
   it('can be enabled via environment variables', done => {
-    process.env.SPLUNK_TRACE_RESPONSE_HEADER_ENABLED = '';
-    const stub = sinon
-      .stub(process.env, 'SPLUNK_TRACE_RESPONSE_HEADER_ENABLED')
-      .value('true');
+    process.env.SPLUNK_TRACE_RESPONSE_HEADER_ENABLED = 'true';
     startTracing({});
     testHeadersAdded(() => {
-      stub.restore();
       done();
     });
   });

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -30,26 +30,26 @@ import * as jaeger from '../src/jaeger';
 import * as utils from './utils';
 
 describe('tracing', () => {
+  let patchJaegerMock;
   let addSpanProcessorMock;
 
-  beforeEach(() => {
-    utils.cleanEnvironment();
+  before(() => {
+    patchJaegerMock = sinon.stub(jaeger, '_patchJaeger');
     addSpanProcessorMock = sinon.stub(
       NodeTracerProvider.prototype,
       'addSpanProcessor'
     );
   });
 
-  afterEach(() => {
-    addSpanProcessorMock.reset();
-    addSpanProcessorMock.restore();
-  });
-
-  const patchJaegerMock = sinon.stub(jaeger, '_patchJaeger');
-
   beforeEach(() => {
+    utils.cleanEnvironment();
     addSpanProcessorMock.reset();
     patchJaegerMock.reset();
+  });
+
+  after(() => {
+    addSpanProcessorMock.restore();
+    patchJaegerMock.restore();
   });
 
   function assertTracingPipeline(

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -27,11 +27,13 @@ import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
 
 import { startTracing, stopTracing } from '../src/tracing';
 import * as jaeger from '../src/jaeger';
+import * as utils from './utils';
 
 describe('tracing', () => {
   let addSpanProcessorMock;
 
   beforeEach(() => {
+    utils.cleanEnvironment();
     addSpanProcessorMock = sinon.stub(
       NodeTracerProvider.prototype,
       'addSpanProcessor'
@@ -127,27 +129,11 @@ describe('tracing', () => {
     const maxAttrLength = 101;
     const logInjectionEnabled = true;
 
-    process.env.OTEL_EXPORTER_JAEGER_ENDPOINT = '';
-    process.env.OTEL_SERVICE_NAME = '';
-    process.env.SPLUNK_ACCESS_TOKEN = '';
-    process.env.SPLUNK_MAX_ATTR_LENGTH = '42';
-    process.env.SPLUNK_LOGS_INJECTION = 'true';
-
-    const envExporterStub = sinon
-      .stub(process.env, 'OTEL_EXPORTER_JAEGER_ENDPOINT')
-      .value(url);
-    const envServiceStub = sinon
-      .stub(process.env, 'OTEL_SERVICE_NAME')
-      .value(serviceName);
-    const envAccessStub = sinon
-      .stub(process.env, 'SPLUNK_ACCESS_TOKEN')
-      .value(accessToken);
-    const envMaxAttrLength = sinon
-      .stub(process.env, 'SPLUNK_MAX_ATTR_LENGTH')
-      .value(maxAttrLength);
-    const envLogsInjection = sinon
-      .stub(process.env, 'SPLUNK_LOGS_INJECTION')
-      .value(logInjectionEnabled);
+    process.env.OTEL_EXPORTER_JAEGER_ENDPOINT = url;
+    process.env.OTEL_SERVICE_NAME = serviceName;
+    process.env.SPLUNK_ACCESS_TOKEN = accessToken;
+    process.env.SPLUNK_MAX_ATTR_LENGTH = maxAttrLength.toString();
+    process.env.SPLUNK_LOGS_INJECTION = logInjectionEnabled.toString();
 
     startTracing();
     assertTracingPipeline(
@@ -158,12 +144,6 @@ describe('tracing', () => {
       logInjectionEnabled
     );
     stopTracing();
-
-    envExporterStub.restore();
-    envServiceStub.restore();
-    envAccessStub.restore();
-    envMaxAttrLength.restore();
-    envLogsInjection.restore();
   });
 
   it('setups tracing with multiple processors', () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const isConfigVarEntry = key => {
+  const lowercased = key.toLowerCase();
+  return (
+    lowercased.includes('splunk_') ||
+    lowercased.includes('signal_') ||
+    lowercased.includes('otel_')
+  );
+};
+
+/*
+	Has a side-effect of deleting environment variables in the running process.
+	To be used in tests to make sure:
+	1. that we don't depend on the actual environment in the tests.
+	2. there are no leaking setup between tests;
+
+	An alternative would be to sinon.stub all relevant options and restore them
+	between runs.
+*/
+export const cleanEnvironment = () => {
+  Object.keys(process.env)
+    .filter(isConfigVarEntry)
+    .forEach(key => {
+      delete process.env[key];
+    });
+};


### PR DESCRIPTION
# Description

Implemented an utility to clear relevant environment variables before running the tests.
Current ones are fortunately well-implemented and didn't have any errors regarding that, but
I stumbled upon fragile tests adding new in another PR.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Internal change (a change which is not visible to the package consumers)
- [ ] Documentation change or requires a documentation update

# How Has This Been Tested?

- [ ] Tested manually
- [x] Added automated tests

# Checklist:

- [x] Unit tests have been added/updated
- [ ] Documentation has been updated
- [ ] Change file has been generated (`npm run change:new`)
