### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,14 @@
 * @signalfx/gdi-js-maintainers @signalfx/gdi-js-approvers
+
+.github/CODEOWNERS @signalfx/gdi-TEAM-maintainers
+
+#####################################################
+#
+# Docs reviewers
+#
+#####################################################
+
+*.md    @signalfx/gdi-js-maintainers @signalfx/gdi-js-approvers @signalfx/docs
+*.rst   @signalfx/gdi-js-maintainers @signalfx/gdi-js-approvers @signalfx/docs
+docs/   @signalfx/gdi-js-maintainers @signalfx/gdi-js-approvers @signalfx/docs
+README* @signalfx/gdi-js-maintainers @signalfx/gdi-js-approvers @signalfx/docs


### PR DESCRIPTION
As per GDI specs template, so that tech writers are included as reviewers of doc changes.