### PR TITLE
chore: upgrade to TypeScript 4.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "sinon": "^11.1.2",
         "ts-mocha": "8.0.0",
         "ts-node": "10.2.1",
-        "typescript": "4.3.5",
+        "typescript": "4.4.3",
         "winston": "3.3.3"
       },
       "engines": {
@@ -9908,9 +9908,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -18025,9 +18025,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "sinon": "^11.1.2",
     "ts-mocha": "8.0.0",
     "ts-node": "10.2.1",
-    "typescript": "4.3.5",
+    "typescript": "4.4.3",
     "winston": "3.3.3"
   },
   "dependencies": {

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -67,7 +67,8 @@ export class EnvResourceDetector {
       const attributes = this._parseResourceAttributes(rawAttributes);
       return new Resource(attributes);
     } catch (e) {
-      diag.debug(`EnvDetector failed: ${e.message}`);
+      const message = e instanceof Error ? e.message : e;
+      diag.debug(`EnvDetector failed: ${message}`);
       return Resource.empty();
     }
   }


### PR DESCRIPTION
Gets rid of https://github.com/signalfx/splunk-otel-js/pull/283