### PR TITLE
feat: add the option to capture URL parameters

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -44,4 +44,4 @@ The following config options can be set by passing them as arguments to `startTr
 
 - `instrumentations`: Can be used to enable additional instrumentation packages.
 
-- `captureRequestUriParams`: Either a list of keys (case-sensitive) of HTTP query parameters to capture or a function which gets invoked with the current span and query parameters to set a custom span attribute. When using the former, parameters are set as span attributes as `http.request.param.${key}`. Attribute keys are normalized at capture time, meaning `.` is replaced with `_` to avoid any attribute namespacing issues.
+- `captureRequestUriParams`: Either a list of keys (case-sensitive) of HTTP query parameters to capture or a function that gets invoked with the current span and query parameters to set a custom span attribute. When using the former, parameters are set as span attributes as `http.request.param.${key}`. Attribute keys are normalized at capture time, meaning `.` is replaced with `_` to avoid any attribute namespacing issues.

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -44,4 +44,4 @@ The following config options can be set by passing them as arguments to `startTr
 
 - `instrumentations`: Can be used to enable additional instrumentation packages.
 
-- `captureRequestUriParams`: Either a list of keys (case-sensitive) of HTTP query parameters to capture or a function that gets invoked with the current span and query parameters to set a custom span attribute. When using the former, parameters are set as span attributes as `http.request.param.${key}`. Attribute keys are normalized at capture time, meaning `.` is replaced with `_` to avoid any attribute namespacing issues.
+- `captureHttpRequestUriParams`: Either a list of keys (case-sensitive) of HTTP query parameters to capture or a function that gets invoked with the current span and query parameters to set a custom span attribute. When using the former, parameters are set as span attributes as `http.request.param.${key}`. Attribute keys are normalized at capture time, meaning `.` is replaced with `_` to avoid any attribute namespacing issues.

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -42,3 +42,5 @@ The following config options can be set by passing them as arguments to `startTr
 - `propagatorFactory`: A function that returns a new instance of a TextMapPropagator. Defaults to a composite propagator comprised of W3C [Trace Context](https://www.w3.org/TR/trace-context/) and [Baggage](https://w3c.github.io/baggage/) propagators.
 
 - `instrumentations`: Can be used to enable additional instrumentation packages.
+
+- `captureRequestUriParams`: Either a list of keys (case-sensitive) of HTTP query parameters to capture or a function which gets invoked with the current span and query parameters to set a custom span attribute. When using the former, parameters are set as span attributes as `http.request.param.${key}`. Attribute keys are normalized at capture time, meaning `.` is replaced with `_` to avoid any attribute namespacing issues.

--- a/src/instrumentations/http.ts
+++ b/src/instrumentations/http.ts
@@ -44,7 +44,7 @@ function parseUrlParams(request: IncomingMessage) {
   }
 
   try {
-    // If Node <11 is supported, need to use the legacy API.
+    // As long as Node <11 is supported, need to use the legacy API.
     // eslint-disable-next-line node/no-deprecated-api
     return Url.parse(request.url || '', true).query;
   } catch (err) {

--- a/src/instrumentations/http.ts
+++ b/src/instrumentations/http.ts
@@ -14,13 +14,106 @@
  * limitations under the License.
  */
 
-import { Options } from '../options';
-import { ServerResponse } from 'http';
+import { Options, CaptureHttpUriParameters } from '../options';
+import { IncomingMessage, ServerResponse } from 'http';
 import {
   HttpInstrumentationConfig,
   HttpResponseCustomAttributeFunction,
+  HttpRequestCustomAttributeFunction,
 } from '@opentelemetry/instrumentation-http';
-import { isSpanContextValid, TraceFlags } from '@opentelemetry/api';
+import { diag, isSpanContextValid, TraceFlags } from '@opentelemetry/api';
+import { Span } from '@opentelemetry/api';
+import * as Url from 'url';
+
+type IncomingHttpRequestHook = (span: Span, request: IncomingMessage) => void;
+
+function shouldAddRequestHook(options: Options): boolean {
+  if (
+    Array.isArray(options.captureRequestUriParams) &&
+    options.captureRequestUriParams.length == 0
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function parseUrlParams(request: IncomingMessage) {
+  if (request.url === undefined) {
+    return {};
+  }
+
+  try {
+    // If Node <11 is supported, need to use the legacy API.
+    // eslint-disable-next-line node/no-deprecated-api
+    return Url.parse(request.url || '', true).query;
+  } catch (err) {
+    diag.debug(`error parsing url '${request.url}`, err);
+  }
+
+  return {};
+}
+
+function captureUriParamByKeys(keys: string[]): IncomingHttpRequestHook {
+  const capturedKeys = new Map(keys.map(k => [k, k.replace(/\./g, '_')]));
+
+  return (span, request) => {
+    const params = parseUrlParams(request);
+
+    for (const [key, normalizedKey] of capturedKeys) {
+      const value = params[key];
+
+      if (value === undefined) {
+        continue;
+      }
+
+      const values = Array.isArray(value) ? value : [value];
+
+      if (values.length > 0) {
+        span.setAttribute(`http.request.param.${normalizedKey}`, values);
+      }
+    }
+  };
+}
+
+function captureUriParamByFunction(
+  process: CaptureHttpUriParameters
+): IncomingHttpRequestHook {
+  return (span, request) => {
+    const params = parseUrlParams(request);
+    process(span, params);
+  };
+}
+
+function createHttpRequestHook(
+  options: Options
+): HttpRequestCustomAttributeFunction {
+  const incomingRequestHooks: IncomingHttpRequestHook[] = [];
+
+  if (Array.isArray(options.captureRequestUriParams)) {
+    incomingRequestHooks.push(
+      captureUriParamByKeys(options.captureRequestUriParams)
+    );
+  } else {
+    incomingRequestHooks.push(
+      captureUriParamByFunction(options.captureRequestUriParams)
+    );
+  }
+
+  return (span, request) => {
+    const spanContext = span.spanContext();
+
+    if (!isSpanContextValid(spanContext)) {
+      return;
+    }
+
+    if (request instanceof IncomingMessage) {
+      for (const hook of incomingRequestHooks) {
+        hook(span, request);
+      }
+    }
+  };
+}
 
 export function configureHttpInstrumentation(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,41 +135,55 @@ export function configureHttpInstrumentation(
     span,
     response
   ) => {
-    if (response instanceof ServerResponse) {
-      const spanContext = span.spanContext();
-
-      if (isSpanContextValid(spanContext)) {
-        const { traceFlags, traceId, spanId } = spanContext;
-        const sampled =
-          (traceFlags & TraceFlags.SAMPLED) === TraceFlags.SAMPLED;
-        const flags = sampled ? '01' : '00';
-
-        appendHeader(
-          response,
-          'Access-Control-Expose-Headers',
-          'Server-Timing'
-        );
-        appendHeader(
-          response,
-          'Server-Timing',
-          `traceparent;desc="00-${traceId}-${spanId}-${flags}"`
-        );
-      }
+    if (!(response instanceof ServerResponse)) {
+      return;
     }
+
+    const spanContext = span.spanContext();
+
+    if (!isSpanContextValid(spanContext)) {
+      return;
+    }
+
+    const { traceFlags, traceId, spanId } = spanContext;
+    const sampled = (traceFlags & TraceFlags.SAMPLED) === TraceFlags.SAMPLED;
+    const flags = sampled ? '01' : '00';
+
+    appendHeader(response, 'Access-Control-Expose-Headers', 'Server-Timing');
+    appendHeader(
+      response,
+      'Server-Timing',
+      `traceparent;desc="00-${traceId}-${spanId}-${flags}"`
+    );
   };
 
   let config = instrumentation._getConfig() as HttpInstrumentationConfig;
 
   if (config === undefined) {
-    config = { responseHook };
-  } else if (config.responseHook !== undefined) {
+    config = {};
+  }
+
+  if (config.responseHook === undefined) {
+    config.responseHook = responseHook;
+  } else {
     const original = config.responseHook;
     config.responseHook = function (this: unknown, span, response) {
       responseHook(span, response);
       original.call(this, span, response);
     };
-  } else {
-    config.responseHook = responseHook;
+  }
+
+  if (shouldAddRequestHook(options)) {
+    const requestHook = createHttpRequestHook(options);
+    if (config.requestHook === undefined) {
+      config.requestHook = requestHook;
+    } else {
+      const original = config.requestHook;
+      config.requestHook = function (this: unknown, span, request) {
+        requestHook(span, request);
+        original.call(this, span, request);
+      };
+    }
   }
 
   instrumentation.setConfig(config);

--- a/src/instrumentations/http.ts
+++ b/src/instrumentations/http.ts
@@ -29,8 +29,8 @@ type IncomingHttpRequestHook = (span: Span, request: IncomingMessage) => void;
 
 function shouldAddRequestHook(options: Options): boolean {
   if (
-    Array.isArray(options.captureRequestUriParams) &&
-    options.captureRequestUriParams.length == 0
+    Array.isArray(options.captureHttpRequestUriParams) &&
+    options.captureHttpRequestUriParams.length == 0
   ) {
     return false;
   }
@@ -90,13 +90,13 @@ function createHttpRequestHook(
 ): HttpRequestCustomAttributeFunction {
   const incomingRequestHooks: IncomingHttpRequestHook[] = [];
 
-  if (Array.isArray(options.captureRequestUriParams)) {
+  if (Array.isArray(options.captureHttpRequestUriParams)) {
     incomingRequestHooks.push(
-      captureUriParamByKeys(options.captureRequestUriParams)
+      captureUriParamByKeys(options.captureHttpRequestUriParams)
     );
   } else {
     incomingRequestHooks.push(
-      captureUriParamByFunction(options.captureRequestUriParams)
+      captureUriParamByFunction(options.captureHttpRequestUriParams)
     );
   }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -26,7 +26,7 @@ import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
 import { EnvResourceDetector } from './resource';
 import { NodeTracerConfig } from '@opentelemetry/sdk-trace-node';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import { TextMapPropagator } from '@opentelemetry/api';
+import { Span, TextMapPropagator } from '@opentelemetry/api';
 import {
   CompositePropagator,
   HttpBaggagePropagator,
@@ -46,6 +46,11 @@ type SpanProcessorFactory = (
 
 type PropagatorFactory = (options: Options) => TextMapPropagator;
 
+export type CaptureHttpUriParameters = (
+  span: Span,
+  params: Record<string, string | string[] | undefined>
+) => void;
+
 export interface Options {
   endpoint?: string;
   serviceName: string;
@@ -58,6 +63,7 @@ export interface Options {
   spanExporterFactory: SpanExporterFactory;
   spanProcessorFactory: SpanProcessorFactory;
   propagatorFactory: PropagatorFactory;
+  captureRequestUriParams: string[] | CaptureHttpUriParameters;
 }
 
 export function _setDefaultOptions(options: Partial<Options> = {}): Options {
@@ -120,6 +126,10 @@ export function _setDefaultOptions(options: Partial<Options> = {}): Options {
     options.instrumentations = getInstrumentations();
   }
 
+  if (options.captureRequestUriParams === undefined) {
+    options.captureRequestUriParams = [];
+  }
+
   return {
     endpoint: options.endpoint,
     serviceName: String(
@@ -134,6 +144,7 @@ export function _setDefaultOptions(options: Partial<Options> = {}): Options {
     spanExporterFactory: options.spanExporterFactory,
     spanProcessorFactory: options.spanProcessorFactory,
     propagatorFactory: options.propagatorFactory,
+    captureRequestUriParams: options.captureRequestUriParams,
   };
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -63,7 +63,7 @@ export interface Options {
   spanExporterFactory: SpanExporterFactory;
   spanProcessorFactory: SpanProcessorFactory;
   propagatorFactory: PropagatorFactory;
-  captureRequestUriParams: string[] | CaptureHttpUriParameters;
+  captureHttpRequestUriParams: string[] | CaptureHttpUriParameters;
 }
 
 export function _setDefaultOptions(options: Partial<Options> = {}): Options {
@@ -126,8 +126,8 @@ export function _setDefaultOptions(options: Partial<Options> = {}): Options {
     options.instrumentations = getInstrumentations();
   }
 
-  if (options.captureRequestUriParams === undefined) {
-    options.captureRequestUriParams = [];
+  if (options.captureHttpRequestUriParams === undefined) {
+    options.captureHttpRequestUriParams = [];
   }
 
   return {
@@ -144,7 +144,7 @@ export function _setDefaultOptions(options: Partial<Options> = {}): Options {
     spanExporterFactory: options.spanExporterFactory,
     spanProcessorFactory: options.spanProcessorFactory,
     propagatorFactory: options.propagatorFactory,
-    captureRequestUriParams: options.captureRequestUriParams,
+    captureHttpRequestUriParams: options.captureHttpRequestUriParams,
   };
 }
 

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -69,7 +69,7 @@ describe('options', () => {
       spanExporterFactory: otlpSpanExporterFactory,
       spanProcessorFactory: defaultSpanProcessorFactory,
       propagatorFactory: defaultPropagatorFactory,
-      captureRequestUriParams: [],
+      captureHttpRequestUriParams: [],
     });
     getInstrumentationsStub.restore();
   });
@@ -94,7 +94,7 @@ describe('options', () => {
       spanExporterFactory: testSpanExporterFactory,
       spanProcessorFactory: testSpanProcessorFactory,
       propagatorFactory: testPropagatorFactory,
-      captureRequestUriParams: ['timestamp'],
+      captureHttpRequestUriParams: ['timestamp'],
     });
 
     assert.deepStrictEqual(options, {
@@ -112,7 +112,7 @@ describe('options', () => {
       spanExporterFactory: testSpanExporterFactory,
       spanProcessorFactory: testSpanProcessorFactory,
       propagatorFactory: testPropagatorFactory,
-      captureRequestUriParams: ['timestamp'],
+      captureHttpRequestUriParams: ['timestamp'],
     });
   });
 

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -69,6 +69,7 @@ describe('options', () => {
       spanExporterFactory: otlpSpanExporterFactory,
       spanProcessorFactory: defaultSpanProcessorFactory,
       propagatorFactory: defaultPropagatorFactory,
+      captureRequestUriParams: [],
     });
     getInstrumentationsStub.restore();
   });
@@ -93,6 +94,7 @@ describe('options', () => {
       spanExporterFactory: testSpanExporterFactory,
       spanProcessorFactory: testSpanProcessorFactory,
       propagatorFactory: testPropagatorFactory,
+      captureRequestUriParams: ['timestamp'],
     });
 
     assert.deepStrictEqual(options, {
@@ -110,6 +112,7 @@ describe('options', () => {
       spanExporterFactory: testSpanExporterFactory,
       spanProcessorFactory: testSpanProcessorFactory,
       propagatorFactory: testPropagatorFactory,
+      captureRequestUriParams: ['timestamp'],
     });
   });
 

--- a/test/uri_parameter_capture.test.ts
+++ b/test/uri_parameter_capture.test.ts
@@ -79,7 +79,7 @@ describe('Capturing URI parameters', () => {
 
   it('uri parameters can be captured by keys', async () => {
     startTracing({
-      captureRequestUriParams: ['sortBy', 'order', 'yes'],
+      captureHttpRequestUriParams: ['sortBy', 'order', 'yes'],
       ...testOpts(),
     });
     setupServer();
@@ -99,7 +99,7 @@ describe('Capturing URI parameters', () => {
 
   it('uri parameters can be captured by user supplied function', async () => {
     startTracing({
-      captureRequestUriParams: (span, params) => {
+      captureHttpRequestUriParams: (span, params) => {
         const value = params['order'];
         if (value === undefined) {
           return;
@@ -124,7 +124,7 @@ describe('Capturing URI parameters', () => {
 
   it('uri parameter keys are normalized', async () => {
     startTracing({
-      captureRequestUriParams: ["'();:@&=+$,/?#[]b ar._&-~-&123!*"],
+      captureHttpRequestUriParams: ["'();:@&=+$,/?#[]b ar._&-~-&123!*"],
       ...testOpts(),
     });
     setupServer();

--- a/test/uri_parameter_capture.test.ts
+++ b/test/uri_parameter_capture.test.ts
@@ -73,7 +73,7 @@ describe('Capturing URI parameters', () => {
     setupServer();
     const [span] = await doRequest(SERVER_URL);
     for (const key of Object.keys(span.attributes)) {
-      assert.doesNotMatch(key, /http\.request\.param\./);
+      assert.equal(key.startsWith('http.request.param'), false);
     }
   });
 

--- a/test/uri_parameter_capture.test.ts
+++ b/test/uri_parameter_capture.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { startTracing } from '../src/tracing';
+import * as utils from './utils';
+import {
+  InMemorySpanExporter,
+  ReadableSpan,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { defaultSpanProcessorFactory } from '../src/options';
+
+const PORT = 9111;
+const SERVER_URL = `http://localhost:${PORT}`;
+
+describe('Capturing URI parameters', () => {
+  let http;
+  let server;
+  let exporter;
+  let spanProcessor: SpanProcessor;
+
+  beforeEach(() => {
+    utils.cleanEnvironment();
+    exporter = new InMemorySpanExporter();
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  const setupServer = () => {
+    http = require('http');
+    server = http.createServer((req, res) => {
+      res.end('ok');
+    });
+    server.listen(PORT);
+  };
+
+  const doRequest = (url: string): Promise<ReadableSpan[]> => {
+    return new Promise((resolve, reject) => {
+      const req = http.get(url, async () => {
+        await spanProcessor.forceFlush();
+        resolve(exporter.getFinishedSpans());
+      });
+      req.on('error', reject);
+      req.end();
+    });
+  };
+
+  const testOpts = () => ({
+    spanExporterFactory: () => exporter,
+    spanProcessorFactory: options => {
+      return (spanProcessor = defaultSpanProcessorFactory(options));
+    },
+  });
+
+  it('no uri parameters are captured by default', async () => {
+    startTracing(testOpts());
+    setupServer();
+    const [span] = await doRequest(SERVER_URL);
+    for (const key of Object.keys(span.attributes)) {
+      assert.doesNotMatch(key, /http\.request\.param\./);
+    }
+  });
+
+  it('uri parameters can be captured by keys', async () => {
+    startTracing({
+      captureRequestUriParams: ['sortBy', 'order', 'yes'],
+      ...testOpts(),
+    });
+    setupServer();
+    const [span] = await doRequest(
+      `${SERVER_URL}/foo?sortBy=name&order=asc&order=desc&quux=123&yes`
+    );
+    assert.deepStrictEqual(span.attributes['http.request.param.sortBy'], [
+      'name',
+    ]);
+    assert.deepStrictEqual(span.attributes['http.request.param.order'], [
+      'asc',
+      'desc',
+    ]);
+    assert.deepStrictEqual(span.attributes['http.request.param.yes'], ['']);
+    assert.deepEqual(span.attributes['http.request.param.quux'], undefined);
+  });
+
+  it('uri parameters can be captured by user supplied function', async () => {
+    startTracing({
+      captureRequestUriParams: (span, params) => {
+        const value = params['order'];
+        if (value === undefined) {
+          return;
+        }
+
+        const values = Array.isArray(value) ? value : [value];
+
+        span.setAttribute('http.request.param.order', values);
+      },
+      ...testOpts(),
+    });
+    setupServer();
+    const [span] = await doRequest(
+      `${SERVER_URL}/foo?sortBy=name&order=asc&quux=123`
+    );
+    assert.equal(span.attributes['http.request.param.sortBy'], undefined);
+    assert.equal(span.attributes['http.request.param.quux'], undefined);
+    assert.deepStrictEqual(span.attributes['http.request.param.order'], [
+      'asc',
+    ]);
+  });
+
+  it('uri parameter keys are normalized', async () => {
+    startTracing({
+      captureRequestUriParams: ["'();:@&=+$,/?#[]b ar._&-~-&123!*"],
+      ...testOpts(),
+    });
+    setupServer();
+    const [span] = await doRequest(
+      `${SERVER_URL}/foo?%27()%3B%3A%40%26%3D%2B%24%2C%2F%3F%23%5B%5Db%20ar._%26-~-%26123!*=42`
+    );
+    assert.deepStrictEqual(
+      span.attributes["http.request.param.'();:@&=+$,/?#[]b ar__&-~-&123!*"],
+      ['42']
+    );
+  });
+});


### PR DESCRIPTION
# Description

Add the option to capture URL parameters from HTTP requests. Capturing can be done either by supplying a list of keys to capture (case-sensitive) or a custom function which gets invoked with the current span and query parameters.

Parameters are set as `http.request.param.${key}` span attribute.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation change or requires a documentation update

# How Has This Been Tested?

- [ ] Tested manually
- [x] Added automated tests

# Checklist:

- [x] Unit tests have been added/updated
- [x] Documentation has been updated
- [ ] Change file has been generated (`npm run change:new`)
- [x] Delete this branch (after the PR is merged)