### PR TITLE
chore: update dependabot to run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,8 @@ updates:
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: "daily"
+      interval: "weekly"
     allowed_updates:
       - match:
           update_type: "security"


### PR DESCRIPTION
Else every day our PR list and git history is spammed with minor updates :cry: 

Also removed the ignored security params which are configured via GitHub and not via yaml.

GitHub's dependabot does not seem to have `allowed_updates` field any more, but has `allow` which however does not control security updates:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#allow