### PR TITLE
chore: fix unused dependabot parameters

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    allowed_updates:
-      - match:
-          update_type: "security"


### PR DESCRIPTION
Was meant to be removed with https://github.com/signalfx/splunk-otel-js/pull/322, but forgot to push changes :facepalm: 

The error can now even be seen in the main branch:
`The property '#/updates/0/' contains additional properties ["allowed_updates"] outside of the schema when none are allowed`