### PR TITLE
fix: use default exporter when the env var is set to empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Then you can automatically instrument your application by running
 node -r @splunk/otel/instrument index.js
 ```
 
-## Correlate traces and logs
+## Correlate traces and logs
 
 The Splunk Distribution of OpenTelemetry JS can make trace metadata available to many Node.js logging libraries capable of accessing them, like Pino, Winston, and Bunyan. You can use trace metadata to correlate traces with log events, and explore logs in Observability Cloud. 
 

--- a/docs/correlate-logs-traces.md
+++ b/docs/correlate-logs-traces.md
@@ -3,7 +3,7 @@
 
 The Splunk Distribution of OpenTelemetry JS automatically injects trace metadata into logs so that Node.js logging libraries can access it. You can use trace metadata to correlate traces with log events and explore logs in Observability Cloud.
 
-## Supported logging libraries
+## Supported logging libraries
 
 The following logging librares are supported:
 
@@ -11,7 +11,7 @@ The following logging librares are supported:
 - Pino
 - Winston
 
-## Available trace data
+## Available trace data
 
 The following attributes are available for applications instrumented using the Splunk distribution of OpenTelemetry JS:
 
@@ -23,7 +23,7 @@ The format of each log message depends on the logging library. The following is 
    {"level":30,"time":1979374615686,"pid":728570,"hostname":"my_host","trace_id":"f8e261432221096329baf5e62090d856","span_id":"3235afe76b55fe51","trace_flags":"01","url":"/lkasd","msg":"request handler"}
 ```
 
-## Enable logs injection
+## Enable logs injection
 
 To enable log injection, install the instrumentation package for your logging library:
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -139,7 +139,7 @@ export function _setDefaultOptions(options: Partial<Options> = {}): Options {
 
 export function resolveTracesExporter(): SpanExporterFactory {
   const factory =
-    SpanExporterMap[process.env.OTEL_TRACES_EXPORTER ?? 'default'];
+    SpanExporterMap[process.env.OTEL_TRACES_EXPORTER || 'default'];
   assert.strictEqual(
     typeof factory,
     'function',


### PR DESCRIPTION
# Description

Currently, we do not support setting `OTEL_TRACES_EXPORTER` to `''` to enforce the default. We need it to support clearing the env in env files for example.
