### PR TITLE
chore: hardcode `signalfx` as the namespace for github release

### DIFF
--- a/scripts/release-github.js
+++ b/scripts/release-github.js
@@ -16,8 +16,8 @@ async function createRelease() {
   const tag = `v${version}`;
   console.log(`Tag: ${tag}`);
 
-  const owner = 'signalfx';
-  const repo = 'splunk-otel-js';
+  const owner = process.env.GITHUB_OWNER ?? 'signalfx';
+  const repo = process.env.GITHUB_REPO ?? 'splunk-otel-js';
   console.log(`Repo: ${owner}/${repo}`);
 
   const commit = process.env.CI_COMMIT_SHA;

--- a/scripts/release-github.js
+++ b/scripts/release-github.js
@@ -16,7 +16,7 @@ async function createRelease() {
   const tag = `v${version}`;
   console.log(`Tag: ${tag}`);
 
-  const owner = 'jtmalinowski';
+  const owner = 'signalfx';
   const repo = 'splunk-otel-js';
   console.log(`Repo: ${owner}/${repo}`);
 


### PR DESCRIPTION
# Description

`release-github.js` had "jtmalinowski" hardcoded as the user/org.

## Type of change

- [ ] Internal change (a change which is not visible to the package consumers)
- [ ] Delete this branch (after the PR is merged)
