### PR TITLE
feat: remove OTEL_TRACE_ENABLED

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -82,7 +82,7 @@ Rename environment variables:
 | SIGNALFX_LOGS_INJECTION_TAGS       | n/a                                    | |
 | SIGNALFX_ENABLED_PLUGINS           | n/a                                    | see [the README section about instrumentations](./README.md#custom-instrumentation-packages) |
 | SIGNALFX_SERVER_TIMING_CONTEXT     | SPLUNK_TRACE_RESPONSE_HEADER_ENABLED   | |
-| SIGNALFX_TRACING_ENABLED           | OTEL_TRACE_ENABLED                     | |
+| SIGNALFX_TRACING_ENABLED           | n/a                                    | |
 
 ### Programmatic configuration
 

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -34,7 +34,6 @@ The following table contain the configuration options supported by this distribu
 | SPLUNK_ACCESS_TOKEN                  | accessToken                     |                                       | The optional access token for exporting signal data directly to SignalFx API.
 | SPLUNK_TRACE_RESPONSE_HEADER_ENABLED | serverTimingEnabled             | `true`                                | Enable injection of `Server-Timing` header to HTTP responses.
 | OTEL_RESOURCE_ATTRIBUTES             |                                 |                                       | Comma-separated list of resource attributes added to every reported span. <details><summary>Example</summary>`key1=val1,key2=val2`</details>
-| OTEL_TRACE_ENABLED                   |                                 | `true`                                | Globally enables tracer creation and auto-instrumentation.
 
 ## Additional config options
 

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -30,10 +30,6 @@ import {
 let unregisterInstrumentations: (() => void) | null = null;
 
 export function startTracing(opts: Partial<Options> = {}): void {
-  if (process.env.OTEL_TRACE_ENABLED === 'false') {
-    return;
-  }
-
   const options = _setDefaultOptions(opts);
 
   // propagator

--- a/test/tracing/tracing.test.ts
+++ b/test/tracing/tracing.test.ts
@@ -67,13 +67,6 @@ describe('tracing:otlp', () => {
     }
   }
 
-  it('does not setup tracing OTEL_TRACE_ENABLED=false', () => {
-    process.env.OTEL_TRACE_ENABLED = 'false';
-    startTracing();
-    sinon.assert.notCalled(addSpanProcessorMock);
-    stopTracing();
-  });
-
   it('setups tracing with defaults', () => {
     startTracing();
     assertTracingPipeline('localhost:4317', 'unnamed-node-service', '');


### PR DESCRIPTION
# Description

Removed from spec in 83fedd3.
Python uses OTEL_TRACES_ENABLED.
Java does not have it at all.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change or requires a documentation update

# Checklist:

- [x] Unit tests have been added/updated
- [x] Documentation has been updated
- [ ] Change file has been generated (`npm run change:new`)
- [ ] Delete this branch (after the PR is merged)
