### PR TITLE
Add service dimension to metrics

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -69,7 +69,7 @@ The following config options can be set by passing them as arguments to `startTr
 - `signalfx`: A JS object with optional `client` and `dimensions` fields. If you have already setup a [SignalFx client](https://github.com/signalfx/signalfx-nodejs) with custom configuration, you can use this for sending instead of creating, configuring a new one. `dimensions` object adds a pre-defined dimension for each datapoint. The format for `dimensions` is `{key: value, ...}`.
 
    The following is a list of dimensions added by default:
-   - `service`: see `serviceName` from the tracing section,
+   - `service`: see [`serviceName`](#tracing) from the tracing section
    - `metric_source`: `splunk-otel-js`
    - `node_version`: `process.versions.node`, e.g. `16.10.0`
 

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -69,7 +69,7 @@ The following config options can be set by passing them as arguments to `startTr
 - `signalfx`: A JS object with optional `client` and `dimensions` fields. If you have already setup a [SignalFx client](https://github.com/signalfx/signalfx-nodejs) with custom configuration, you can use this for sending instead of creating, configuring a new one. `dimensions` object adds a pre-defined dimension for each datapoint. The format for `dimensions` is `{key: value, ...}`.
 
    The following is a list of dimensions added by default:
-   - `host`: `os.hostname()`
+   - `service`: see `serviceName` from the tracing section,
    - `metric_source`: `splunk-otel-js`
    - `node_version`: `process.versions.node`, e.g. `16.10.0`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "winston": "3.3.3"
       },
       "engines": {
-        "node": ">=8.5.0 <17"
+        "node": ">=8.5.0 <18"
       },
       "peerDependencies": {
         "@opentelemetry/instrumentation-bunyan": ">=0.25.0 <1",

--- a/src/options.ts
+++ b/src/options.ts
@@ -37,7 +37,7 @@ import {
 import { SplunkBatchSpanProcessor } from './SplunkBatchSpanProcessor';
 import { Resource } from '@opentelemetry/resources';
 
-const defaultServiceName = 'unnamed-node-service';
+export const defaultServiceName = 'unnamed-node-service';
 
 type SpanExporterFactory = (options: Options) => SpanExporter;
 

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -95,13 +95,14 @@ describe('metrics', () => {
     it('has expected defaults', () => {
       const options = _setDefaultOptions();
       assert.deepEqual(options.enabled, false);
+      assert.deepEqual(options.serviceName, 'unnamed-node-service');
       assert.deepEqual(options.accessToken, '');
       assert.deepEqual(options.endpoint, 'http://localhost:9943');
       assert.deepEqual(options.exportInterval, 5000);
 
       const sfxClient = options.sfxClient;
       assert.deepStrictEqual(sfxClient['globalDimensions'], {
-        host: os.hostname(),
+        service: 'unnamed-node-service',
         metric_source: 'splunk-otel-js',
         node_version: process.versions.node,
       });
@@ -109,15 +110,24 @@ describe('metrics', () => {
 
     it('is possible to set options via env vars', () => {
       process.env.SPLUNK_ACCESS_TOKEN = 'foo';
+      process.env.OTEL_SERVICE_NAME = 'bigmetric';
       process.env.SPLUNK_METRICS_ENABLED = 'true';
       process.env.SPLUNK_METRICS_ENDPOINT = 'http://localhost:9999';
       process.env.SPLUNK_METRICS_EXPORT_INTERVAL = '1000';
 
       const options = _setDefaultOptions();
       assert.deepEqual(options.enabled, true);
+      assert.deepEqual(options.serviceName, 'bigmetric');
       assert.deepEqual(options.accessToken, 'foo');
       assert.deepEqual(options.endpoint, 'http://localhost:9999');
       assert.deepEqual(options.exportInterval, 1000);
+
+      const sfxClient = options.sfxClient;
+      assert.deepStrictEqual(sfxClient['globalDimensions'], {
+        service: 'bigmetric',
+        metric_source: 'splunk-otel-js',
+        node_version: process.versions.node,
+      });
     });
   });
 


### PR DESCRIPTION
- Remove `host` dimension as it should come from collector
- Add `service` dimension with the same logic as is done for `startTracing`