### PR TITLE
profiler: set default collection interval to 30s

### DIFF
--- a/src/native_ext/profiling.cpp
+++ b/src/native_ext/profiling.cpp
@@ -27,7 +27,7 @@ const int64_t kActivationBinWidth = 100L * 1000000L;
  * or matching against the whole profiling period.
  */
 const int64_t kActivationsPerBin = 64;
-const int64_t kBinsPerActivationPeriod = 512;
+const int64_t kBinsPerActivationPeriod = 384;
 
 struct SpanActivation {
   char traceId[32];
@@ -282,6 +282,11 @@ void BinInsertActivation(Profiling* profiling, ActivationBin* bin, SpanActivatio
   // If the last bin is empty, expand
   if (bin->count == kActivationsPerBin) {
     ActivationBin* newBin = (ActivationBin*)ArenaAlloc(profiling, sizeof(ActivationBin));
+
+    if (!newBin) {
+      return;
+    }
+
     newBin->index = bin->index;
     newBin->period = bin->period;
     bin->next = newBin;
@@ -493,7 +498,7 @@ struct StacktraceBuilder {
   }
 
   String Build() {
-    constexpr char prefix[] = "\n\n";
+    static const char prefix[] = "\n\n";
 
     size_t bytesNeeded = sizeof(prefix) - 1;
 

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -151,7 +151,7 @@ export function _setDefaultOptions(
     callstackInterval:
       options.callstackInterval ||
       getEnvNumber('SPLUNK_PROFILER_CALL_STACK_INTERVAL', 1000),
-    collectionDuration: options.collectionDuration || 60_000,
+    collectionDuration: options.collectionDuration || 30_000,
     resource,
     debugExport: options.debugExport ?? false,
   };

--- a/src/profiling/profiling_contextmanager.ts
+++ b/src/profiling/profiling_contextmanager.ts
@@ -60,6 +60,5 @@ export class ProfilingContextManager extends AsyncHooksContextManager {
     if (context) {
       this._recorder.exitContext(context);
     }
-    return context;
   }
 }


### PR DESCRIPTION
* Reduced preallocated bin count due to the lower collection threshold. Slight memory usage reduction.
* Unrelated: check for allocation failure, remove use of constexpr.