### PR TITLE
feat: add env var to incorporate redis command's arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'windows-2019', 'macos-latest']
         nodejs: ['10', '12', '14', '16', '17']
     steps:
       - name: Checkout

--- a/change/@splunk-otel-eeb68c70-397f-4f96-bf05-17cb1721ce8a.json
+++ b/change/@splunk-otel-eeb68c70-397f-4f96-bf05-17cb1721ce8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add SPLUNK_REDIS_INCLUDE_COMMAND_ARGS env var to include redis command args in span's db.statement",
+  "packageName": "@splunk/otel",
+  "email": "siimkallas@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -39,6 +39,7 @@ This distribution supports all the configuration options supported by the compon
 | `OTEL_TRACES_SAMPLER_ARG`                                       |                         | Stable  | String value to be used as the sampler argument. Only be used if OTEL_TRACES_SAMPLER is set.
 | `SPLUNK_ACCESS_TOKEN`<br>`accessToken`                          |                         | Stable  | The optional access token for exporting signal data directly to SignalFx API.
 | `SPLUNK_TRACE_RESPONSE_HEADER_ENABLED`<br>`serverTimingEnabled` | `true`                  | Stable  | Enable injection of `Server-Timing` header to HTTP responses.
+| `SPLUNK_REDIS_INCLUDE_COMMAND_ARGS` | `false`                  | Stable  | Will include the full redis query in `db.statement` span attribute when using `redis` instrumentation.
 
 #### Additional `startTracing` config options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "pino": "^6.13.2",
         "prebuildify": "5.0.0",
         "prettier": ">=2.3.2",
+        "redis": "^3.1.2",
         "rewire": "^5.0.0",
         "rimraf": "3.0.2",
         "shimmer": "1.2.1",
@@ -3785,6 +3786,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -4700,6 +4710,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/fastify-warning/-/fastify-warning-0.2.0.tgz",
       "integrity": "sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==",
+      "deprecated": "This module renamed to process-warning",
       "dev": true
     },
     "node_modules/fastq": {
@@ -5116,20 +5127,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -9034,6 +9031,52 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redis": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "dev": true,
+      "dependencies": {
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-redis"
+      }
+    },
+    "node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+      "dev": true
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "dev": true,
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/regex-not": {
@@ -14715,6 +14758,12 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "dev": true
+    },
     "deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -15763,13 +15812,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -18757,6 +18799,39 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
+      }
+    },
+    "redis": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "dev": true,
+      "requires": {
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+      "dev": true
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
+      "dev": true
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "dev": true,
+      "requires": {
+        "redis-errors": "^1.0.0"
       }
     },
     "regex-not": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,9 @@
       "engines": {
         "node": ">=8.5.0 <18"
       },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      },
       "peerDependencies": {
         "@opentelemetry/instrumentation-bunyan": ">=0.25.0 <1",
         "@opentelemetry/instrumentation-cassandra-driver": ">=0.25.0 <1",
@@ -5127,6 +5130,19 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -15812,6 +15828,12 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -36,6 +36,7 @@
         "@opentelemetry/instrumentation-bunyan": "^0.27.0",
         "@opentelemetry/instrumentation-http": "^0.27.0",
         "@opentelemetry/instrumentation-pino": "^0.28.0",
+        "@opentelemetry/instrumentation-redis": "^0.27.0",
         "@opentelemetry/instrumentation-winston": "^0.27.0",
         "@types/bunyan": "1.8.7",
         "@types/mocha": "9.0.0",
@@ -1591,6 +1592,23 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-redis": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.27.0.tgz",
+      "integrity": "sha512-A54NWDuqnTk0XImM64eDhNuvn139scUBxPbkea+Y5QqLKac83XGpVsGI2RCSN4dR2KLurdDI2B3qBVkJ5mxAzA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.27.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@types/redis": "2.8.31"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.2"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-winston": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.27.0.tgz",
@@ -1923,6 +1941,15 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "node_modules/@types/redis": {
+      "version": "2.8.31",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.31.tgz",
+      "integrity": "sha512-daWrrTDYaa5iSDFbgzZ9gOOzyp2AJmYK59OlG/2KGBgYWF3lfs8GDKm1c//tik5Uc93hDD36O+qLPvzDolChbA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.3.9",
@@ -12886,7 +12913,8 @@
     "@opentelemetry/context-async-hooks": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.0.1.tgz",
-      "integrity": "sha512-oGCPjDlZ03gXPAdLxw5iqaQJIpL8BZFaiZhAPgF7Vj6XYmrmrA/FXVIsjfNECQTa2D+lt5p8vf0xYIkFufgceQ=="
+      "integrity": "sha512-oGCPjDlZ03gXPAdLxw5iqaQJIpL8BZFaiZhAPgF7Vj6XYmrmrA/FXVIsjfNECQTa2D+lt5p8vf0xYIkFufgceQ==",
+      "requires": {}
     },
     "@opentelemetry/core": {
       "version": "1.0.1",
@@ -13014,6 +13042,17 @@
             "atomic-sleep": "^1.0.0"
           }
         }
+      }
+    },
+    "@opentelemetry/instrumentation-redis": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.27.0.tgz",
+      "integrity": "sha512-A54NWDuqnTk0XImM64eDhNuvn139scUBxPbkea+Y5QqLKac83XGpVsGI2RCSN4dR2KLurdDI2B3qBVkJ5mxAzA==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.27.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@types/redis": "2.8.31"
       }
     },
     "@opentelemetry/instrumentation-winston": {
@@ -13301,6 +13340,15 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/redis": {
+      "version": "2.8.31",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.31.tgz",
+      "integrity": "sha512-daWrrTDYaa5iSDFbgzZ9gOOzyp2AJmYK59OlG/2KGBgYWF3lfs8GDKm1c//tik5Uc93hDD36O+qLPvzDolChbA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/semver": {
       "version": "7.3.9",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
@@ -13496,7 +13544,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -14916,7 +14965,8 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
       "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-es": {
       "version": "3.0.1",
@@ -14949,7 +14999,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
       "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-node": {
       "version": "11.1.0",
@@ -20851,7 +20902,8 @@
     "ws": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
-      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA=="
+      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,9 +75,6 @@
       "engines": {
         "node": ">=8.5.0 <18"
       },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      },
       "peerDependencies": {
         "@opentelemetry/instrumentation-bunyan": ">=0.25.0 <1",
         "@opentelemetry/instrumentation-cassandra-driver": ">=0.25.0 <1",
@@ -4713,7 +4710,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/fastify-warning/-/fastify-warning-0.2.0.tgz",
       "integrity": "sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==",
-      "deprecated": "This module renamed to process-warning",
       "dev": true
     },
     "node_modules/fastq": {
@@ -5135,6 +5131,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -15833,6 +15830,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "pino": "^6.13.2",
     "prebuildify": "5.0.0",
     "prettier": ">=2.3.2",
+    "redis": "^3.1.2",
     "rewire": "^5.0.0",
     "rimraf": "3.0.2",
     "shimmer": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,9 @@
     "semver": "^7.3.5",
     "signalfx": "7.4.1"
   },
+  "optionalDependencies": {
+    "fsevents": "^2.3.2"
+  },
   "peerDependencies": {
     "@opentelemetry/instrumentation-bunyan": ">=0.25.0 <1",
     "@opentelemetry/instrumentation-cassandra-driver": ">=0.25.0 <1",

--- a/package.json
+++ b/package.json
@@ -123,9 +123,6 @@
     "semver": "^7.3.5",
     "signalfx": "7.4.1"
   },
-  "optionalDependencies": {
-    "fsevents": "^2.3.2"
-  },
   "peerDependencies": {
     "@opentelemetry/instrumentation-bunyan": ">=0.25.0 <1",
     "@opentelemetry/instrumentation-cassandra-driver": ">=0.25.0 <1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@opentelemetry/instrumentation-http": "^0.27.0",
     "@opentelemetry/instrumentation-pino": "^0.28.0",
     "@opentelemetry/instrumentation-winston": "^0.27.0",
+    "@opentelemetry/instrumentation-redis": "^0.27.0",
     "@types/bunyan": "1.8.7",
     "@types/mocha": "9.0.0",
     "@types/node": "^16.10.3",

--- a/src/instrumentations/redis.ts
+++ b/src/instrumentations/redis.ts
@@ -33,7 +33,16 @@ export function configureRedisInstrumentation(
       ...config,
       dbStatementSerializer: (cmd, args) => {
         if (args.length === 0) return cmd;
-        return `${cmd} ${args.join(' ')}`;
+
+        const sanitizedArgs = args.map(arg => {
+          if (Buffer.isBuffer(arg)) {
+            return `buffer(${arg.length})`;
+          }
+
+          return arg;
+        });
+
+        return `${cmd} ${sanitizedArgs.join(' ')}`;
       },
     });
   }

--- a/src/instrumentations/redis.ts
+++ b/src/instrumentations/redis.ts
@@ -26,7 +26,7 @@ export function configureRedisInstrumentation(
   _options: Options
 ) {
   const redisInstrumentation = instrumentation as RedisInstrumentation;
-  if (getEnvBoolean('SPLUNK_REDIS_INCLUDE_COMMAND_ARGS')) {
+  if (getEnvBoolean('SPLUNK_REDIS_INCLUDE_COMMAND_ARGS', false)) {
     const config =
       redisInstrumentation.getConfig() as RedisInstrumentationConfig;
     redisInstrumentation.setConfig({

--- a/src/instrumentations/redis.ts
+++ b/src/instrumentations/redis.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  RedisInstrumentation,
+  RedisInstrumentationConfig,
+} from '@opentelemetry/instrumentation-redis';
+import { getEnvBoolean, Options } from '../options';
+
+export function configureRedisInstrumentation(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  instrumentation: any,
+  _options: Options
+) {
+  const redisInstrumentation = instrumentation as RedisInstrumentation;
+  if (getEnvBoolean('SPLUNK_REDIS_INCLUDE_COMMAND_ARGS')) {
+    const config =
+      redisInstrumentation.getConfig() as RedisInstrumentationConfig;
+    redisInstrumentation.setConfig({
+      ...config,
+      dbStatementSerializer: (cmd, args) => {
+        if (args.length === 0) return cmd;
+        return `${cmd} ${args.join(' ')}`;
+      },
+    });
+  }
+}

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -26,6 +26,7 @@ import {
   AsyncHooksContextManager,
   AsyncLocalStorageContextManager,
 } from '@opentelemetry/context-async-hooks';
+import { configureRedisInstrumentation } from './instrumentations/redis';
 
 let unregisterInstrumentations: (() => void) | null = null;
 
@@ -85,6 +86,9 @@ function configureInstrumentations(options: Options) {
     switch (instr['instrumentationName']) {
       case '@opentelemetry/instrumentation-http':
         configureHttpInstrumentation(instr, options);
+        break;
+      case '@opentelemetry/instrumentation-redis':
+        configureRedisInstrumentation(instr, options);
         break;
       case '@opentelemetry/instrumentation-bunyan':
       case '@opentelemetry/instrumentation-pino':

--- a/test/instrumentation/redis.test.ts
+++ b/test/instrumentation/redis.test.ts
@@ -61,9 +61,7 @@ describe('Redis instrumentation', () => {
 
   const testOpts = () => ({
     serviceName: 'test-service',
-    instrumentations: [
-      new RedisInstrumentation(),
-    ],
+    instrumentations: [new RedisInstrumentation()],
     spanExporterFactory: () => exporter,
     spanProcessorFactory: options => {
       return (spanProcessor = defaultSpanProcessorFactory(options));

--- a/test/instrumentation/redis.test.ts
+++ b/test/instrumentation/redis.test.ts
@@ -21,8 +21,10 @@ import {
   SpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { defaultSpanProcessorFactory } from '../../src/options';
+import * as utils from '../utils';
 import * as net from 'net';
 import type * as Redis from 'redis';
+import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis';
 
 describe('Redis instrumentation', () => {
   let redisServer;
@@ -49,10 +51,19 @@ describe('Redis instrumentation', () => {
   });
 
   beforeEach(() => {
+    utils.cleanEnvironment();
     exporter = new InMemorySpanExporter();
   });
 
+  afterEach(() => {
+    utils.cleanEnvironment();
+  });
+
   const testOpts = () => ({
+    serviceName: 'test-service',
+    instrumentations: [
+      new RedisInstrumentation(),
+    ],
     spanExporterFactory: () => exporter,
     spanProcessorFactory: options => {
       return (spanProcessor = defaultSpanProcessorFactory(options));

--- a/test/instrumentation/redis.test.ts
+++ b/test/instrumentation/redis.test.ts
@@ -74,7 +74,7 @@ describe('Redis instrumentation', () => {
     });
   });
 
-  it('db statement is added when setting SPLUNK_REDIS_INCLUDE_COMMAND_ARGS env var ', done => {
+  it('db statement is added when setting SPLUNK_REDIS_INCLUDE_COMMAND_ARGS env var', done => {
     process.env.SPLUNK_REDIS_INCLUDE_COMMAND_ARGS = 'true';
     startTracing(testOpts());
     const client = require('redis').createClient({

--- a/test/instrumentation/redis.test.ts
+++ b/test/instrumentation/redis.test.ts
@@ -69,6 +69,7 @@ describe('Redis instrumentation', () => {
     client.hget('foo', 'bar', async () => {
       await spanProcessor.forceFlush();
       const [span] = await exporter.getFinishedSpans();
+      client.end(false);
       assert.deepStrictEqual(span.attributes['db.statement'], 'hget');
       done();
     });
@@ -83,6 +84,7 @@ describe('Redis instrumentation', () => {
     client.hget('foo', 'bar', async () => {
       await spanProcessor.forceFlush();
       const [span] = await exporter.getFinishedSpans();
+      client.end(false);
       assert.deepStrictEqual(span.attributes['db.statement'], 'hget foo bar');
       done();
     });

--- a/test/instrumentation/redis.test.ts
+++ b/test/instrumentation/redis.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { startTracing } from '../../src/tracing';
+import * as utils from '../utils';
+import {
+  InMemorySpanExporter,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { defaultSpanProcessorFactory } from '../../src/options';
+import * as net from 'net';
+import type * as Redis from 'redis';
+
+describe('Redis instrumentation', () => {
+  let redisServer;
+  let exporter;
+  let spanProcessor: SpanProcessor;
+
+  before(() => {
+    redisServer = net.createServer(socket => {
+      let data = '';
+      socket.on('data', d => {
+        data += d;
+
+        if (data.endsWith('bar\r\n')) {
+          socket.write('$2\r\nok\r\n');
+          data = '';
+        }
+      });
+    });
+    redisServer.listen(6379);
+  });
+
+  after(() => {
+    redisServer.close();
+  });
+
+  beforeEach(() => {
+    utils.cleanEnvironment();
+    exporter = new InMemorySpanExporter();
+  });
+
+  const testOpts = () => ({
+    spanExporterFactory: () => exporter,
+    spanProcessorFactory: options => {
+      return (spanProcessor = defaultSpanProcessorFactory(options));
+    },
+  });
+
+  it('db statement is not added by default', done => {
+    startTracing(testOpts());
+    const client = require('redis').createClient({
+      no_ready_check: true,
+    });
+    client.hget('foo', 'bar', async () => {
+      await spanProcessor.forceFlush();
+      const [span] = await exporter.getFinishedSpans();
+      assert.deepStrictEqual(span.attributes['db.statement'], 'hget');
+      done();
+    });
+  });
+
+  it('db statement is added when setting SPLUNK_REDIS_INCLUDE_COMMAND_ARGS env var ', done => {
+    process.env.SPLUNK_REDIS_INCLUDE_COMMAND_ARGS = 'true';
+    startTracing(testOpts());
+    const client = require('redis').createClient({
+      no_ready_check: true,
+    });
+    client.hget('foo', 'bar', async () => {
+      await spanProcessor.forceFlush();
+      const [span] = await exporter.getFinishedSpans();
+      assert.deepStrictEqual(span.attributes['db.statement'], 'hget foo bar');
+      done();
+    });
+  });
+});

--- a/test/instrumentations.test.ts
+++ b/test/instrumentations.test.ts
@@ -62,7 +62,7 @@ describe('instrumentations', () => {
   it('does not load if packages are not installed', () => {
     const inst = instrumentations.getInstrumentations();
     // Note: the number here is the devDependencies instrumentation count.
-    assert.strictEqual(inst.length, 4);
+    assert.strictEqual(inst.length, 5);
   });
 
   it('load instrumentations if they are not installed', () => {


### PR DESCRIPTION
New boolean env var `SPLUNK_REDIS_INCLUDE_COMMAND_ARGS`.

If set to `true`, we'll use a custom `dbStatementSerializer` for `redis` instrumentation to include the command arguments. The default logic only included the command name.

`db.statement` attribute will become:
when the flag is disabled (by default): `GET foo` -> `GET`
when enabled: `GET foo` -> `GET foo`