### PR TITLE
chore: remove jaeger-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@opentelemetry/sdk-trace-base": "~1.0.0",
         "@opentelemetry/sdk-trace-node": "~1.0.0",
         "@opentelemetry/semantic-conventions": "~1.0.0",
-        "jaeger-client": "^3.18.1",
         "nan": "2.15.0",
         "node-gyp-build": "^4.3.0",
         "semver": "^7.3.5",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "@opentelemetry/sdk-trace-base": "~1.0.0",
     "@opentelemetry/sdk-trace-node": "~1.0.0",
     "@opentelemetry/semantic-conventions": "~1.0.0",
-    "jaeger-client": "^3.18.1",
     "nan": "2.15.0",
     "node-gyp-build": "^4.3.0",
     "semver": "^7.3.5",


### PR DESCRIPTION
Not directly used in our code. OTel Jaeger exporter still brings in the package however.