### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@splunk/otel",
   "entries": [
     {
+      "date": "Thu, 21 Apr 2022 17:01:07 GMT",
+      "tag": "@splunk/otel_v0.18.0",
+      "version": "0.18.0",
+      "comments": {
+        "minor": [
+          {
+            "author": "siimkallas@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "5b4212652929672e174dc63f8eef879538eb0aad",
+            "comment": "remove enabled flag from startMetrics options"
+          }
+        ]
+      }
+    },
+    {
       "date": "Mon, 28 Feb 2022 12:54:34 GMT",
       "tag": "@splunk/otel_v0.17.0",
       "version": "0.17.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
 # Change Log - @splunk/otel
 
-This log was last generated on Mon, 28 Feb 2022 12:54:34 GMT and should not be manually modified.
+This log was last generated on Thu, 21 Apr 2022 17:01:07 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.18.0
+
+Thu, 21 Apr 2022 17:01:07 GMT
+
+### Minor changes
+
+- refactor: remove enabled flag from startMetrics options [#429](https://github.com/signalfx/splunk-otel-js/pull/429)
+- chore: [update minimist to 1.2.6](https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795) [#435](https://github.com/signalfx/splunk-otel-js/pull/435)
+- chore: remove unnecessary dependency on jaeger-client [#445](https://github.com/signalfx/splunk-otel-js/pull/445)
 
 ## 0.17.0
 

--- a/change/@splunk-otel-c79d7401-d939-4997-b613-c4d48d65fdbe.json
+++ b/change/@splunk-otel-c79d7401-d939-4997-b613-c4d48d65fdbe.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "remove enabled flag from startMetrics options",
-  "packageName": "@splunk/otel",
-  "email": "siimkallas@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/instrumentation-http": "^0.25.0",
-    "@splunk/otel": "^0.16.0",
+    "@splunk/otel": "^0.17.0",
     "axios": "^0.21.1",
     "express": "^4.17.1"
   }

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation-express": "^0.25.0",
     "@opentelemetry/instrumentation-http": "^0.25.0",
-    "@splunk/otel": "^0.16.0",
+    "@splunk/otel": "^0.17.0",
     "axios": "^0.21.1",
     "env-cmd": "^10.1.0",
     "express": "^4.17.1",

--- a/examples/log-injection/package.json
+++ b/examples/log-injection/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/instrumentation-pino": "^0.25.0",
-    "@splunk/otel": "^0.16.0",
+    "@splunk/otel": "^0.17.0",
     "pino": "^6.13.3"
   }
 }

--- a/examples/logs/package.json
+++ b/examples/logs/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
-    "@splunk/otel": "^0.16.0"
+    "@splunk/otel": "^0.17.0"
   }
 }

--- a/examples/mixed/package.json
+++ b/examples/mixed/package.json
@@ -9,7 +9,7 @@
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/instrumentation-http": "^0.25.0",
     "@opentelemetry/instrumentation-pino": "^0.25.0",
-    "@splunk/otel": "^0.16.0",
+    "@splunk/otel": "^0.17.0",
     "pino": "^6.13.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '0.17.0';
+export const VERSION = '0.18.0';


### PR DESCRIPTION
# Changes

- refactor: remove enabled flag from startMetrics options [#429](https://github.com/signalfx/splunk-otel-js/pull/429)
- chore: [update minimist to 1.2.6](https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795) [#435](https://github.com/signalfx/splunk-otel-js/pull/435)
- chore: remove unnecessary dependency on jaeger-client [#445](https://github.com/signalfx/splunk-otel-js/pull/445)
- plus various dependabot package updates