### PR TITLE
chore: allow gitlab prereleases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: Continuous Integration
 on:
   pull_request:
   push:
-    branches:
-      - main
 permissions: read-all
 
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,25 +4,27 @@ default:
 stages:
   - release
 
+.prepare_dist: &prepare_dist
+  - npm install
+  - npm run prepare-release-artifact
+  - shasum -a 256 dist/* > dist/checksums.txt
+
+.release_npm: &release_npm
+  - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+  - npm publish ./dist/splunk-otel-${CI_COMMIT_REF_NAME:1}.tgz
+  - rm -f ~/.npmrc
+
 release:
   stage: release
   artifacts:
     paths:
       - dist/
   rules:
-    - if: $CI_COMMIT_BRANCH == "main" && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
   script:
-    - npm install
-    - npm run prepare-release-artifact
-    - shasum -a 256 dist/* > dist/checksums.txt
-
-    # release in Github
+    - *prepare_dist
     - npm run release:github
-
-    # release in NPM
-    - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-    - npm publish ./dist/splunk-otel-${CI_COMMIT_REF_NAME:1}.tgz
-    - rm -f ~/.npmrc
+    - *release_npm
 
 prerelease:
   stage: release
@@ -30,13 +32,7 @@ prerelease:
     paths:
       - dist/
   rules:
-    - if: $CI_COMMIT_BRANCH =~ /^prerelease-.+/ && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-.+/
+    - if: $CI_COMMIT_TAG =~ /^prerelease-v[0-9]+\.[0-9]+\.[0-9]+(?:-.+)?$/
   script:
-    - npm install
-    - npm run prepare-release-artifact
-    - shasum -a 256 dist/* > dist/checksums.txt
-
-    # release in NPM
-    - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-    - npm publish --tag prerelease ./dist/splunk-otel-${CI_COMMIT_REF_NAME:1}.tgz
-    - rm -f ~/.npmrc
+    - *prepare_dist
+    - *release_npm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,5 +33,5 @@ prerelease:
   script:
     - *prepare_dist
     - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-    - npm publish --tag prerelease ./dist/splunk-otel-${CI_COMMIT_REF_NAME:11}.tgz
+    - npm publish --tag prerelease ./dist/splunk-otel-${CI_COMMIT_REF_NAME:12}.tgz
     - rm -f ~/.npmrc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,10 +9,8 @@ release:
   artifacts:
     paths:
       - dist/
-  only:
-    - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
-  except:
-    - branches
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main" && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
   script:
     - npm install
     - npm run prepare-release-artifact
@@ -24,4 +22,21 @@ release:
     # release in NPM
     - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
     - npm publish ./dist/splunk-otel-${CI_COMMIT_REF_NAME:1}.tgz
+    - rm -f ~/.npmrc
+
+prerelease:
+  stage: release
+  artifacts:
+    paths:
+      - dist/
+  rules:
+    - if: $CI_COMMIT_BRANCH == "prerelease" && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-.+/
+  script:
+    - npm install
+    - npm run prepare-release-artifact
+    - shasum -a 256 dist/* > dist/checksums.txt
+
+    # release in NPM
+    - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+    - npm publish --tag prerelease ./dist/splunk-otel-${CI_COMMIT_REF_NAME:1}.tgz
     - rm -f ~/.npmrc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ prerelease:
     paths:
       - dist/
   rules:
-    - if: $CI_COMMIT_BRANCH == "prerelease" && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-.+/
+    - if: $CI_COMMIT_BRANCH =~ /^prerelease-.+/ && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-.+/
   script:
     - npm install
     - npm run prepare-release-artifact

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,11 +9,6 @@ stages:
   - npm run prepare-release-artifact
   - shasum -a 256 dist/* > dist/checksums.txt
 
-.release_npm: &release_npm
-  - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-  - npm publish ./dist/splunk-otel-${CI_COMMIT_REF_NAME:1}.tgz
-  - rm -f ~/.npmrc
-
 release:
   stage: release
   artifacts:
@@ -24,7 +19,9 @@ release:
   script:
     - *prepare_dist
     - npm run release:github
-    - *release_npm
+    - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+    - npm publish ./dist/splunk-otel-${CI_COMMIT_REF_NAME:1}.tgz
+    - rm -f ~/.npmrc
 
 prerelease:
   stage: release
@@ -35,4 +32,6 @@ prerelease:
     - if: $CI_COMMIT_TAG =~ /^prerelease-v[0-9]+\.[0-9]+\.[0-9]+(?:-.+)?$/
   script:
     - *prepare_dist
-    - *release_npm
+    - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+    - npm publish --tag prerelease ./dist/splunk-otel-${CI_COMMIT_REF_NAME:11}.tgz
+    - rm -f ~/.npmrc


### PR DESCRIPTION
Tags with name matching `prerelease-v[0-9]+\.[0-9]+\.[0-9]+(?:-.+)?$`, e.g. `prerelease-v0.21.0` can be used to publish to npm. GitHub releases are skipped to avoid polluting releases list with experimental releases.