### PR TITLE
chore: remove branch check from prepare-release-artifact

### DIFF
--- a/scripts/prepare-release-artifact.js
+++ b/scripts/prepare-release-artifact.js
@@ -15,7 +15,6 @@ async function fetchWorkflowRun(context) {
   const { data: workflows } = await context.octokit.rest.actions.listWorkflowRunsForRepo({
     owner: context.owner,
     repo: context.repo,
-    branch: process.env.CI_COMMIT_BRANCH ?? 'main',
   });
 
   const runs = workflows.workflow_runs;


### PR DESCRIPTION
`CI_COMMIT_BRANCH` is not available on tag pushes anyway and the option would always default to `main`. This is needed for the prerelease tag pushing, so feature branches can be used.