### PR TITLE
feat: make loading instrumentations npm-link-safe

### DIFF
--- a/change/@splunk-otel-7e8fbff4-a7ff-4cb3-97dc-70625c2a91e5.json
+++ b/change/@splunk-otel-7e8fbff4-a7ff-4cb3-97dc-70625c2a91e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: make loading instrumentations npm-link-safe",
+  "packageName": "@splunk/otel",
+  "email": "rauno56@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/instrumentations/loader.ts
+++ b/src/instrumentations/loader.ts
@@ -16,19 +16,36 @@
 
 import { diag } from '@opentelemetry/api';
 import { Instrumentation } from '@opentelemetry/instrumentation';
+import { createRequire } from 'module';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type InstrumentationConstructor = { new (config?: any): Instrumentation };
+
+const linkSafeRequire = createRequire(require?.main?.filename || __filename);
 
 export function load(
   module: string,
   instrumentation: string
 ): InstrumentationConstructor | null {
   try {
+    const loadedModule = linkSafeRequire(module);
+
+    if (loadedModule[instrumentation]) {
+      return loadedModule[instrumentation]
+    }
+  } catch {
+    // Ignoring errors and attempting the common case
+  }
+
+  try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     return require(module)[instrumentation];
-  } catch (e) {
-    diag.debug('cannot find instrumentation package: ' + instrumentation);
+  } catch (e: any) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      diag.debug('cannot find instrumentation package:', module);
+    } else {
+      diag.debug('Errored loading instrumentation:', e.message, e.code);
+    }
   }
   return null;
 }

--- a/test/instrumentations.test.ts
+++ b/test/instrumentations.test.ts
@@ -21,6 +21,8 @@ import * as rewire from 'rewire';
 import * as instrumentations from '../src/instrumentations';
 import * as loader from '../src/instrumentations/loader';
 
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
+
 describe('instrumentations', () => {
   it('does not load if packages are not installed', () => {
     const inst = instrumentations.getInstrumentations();
@@ -58,18 +60,13 @@ describe('instrumentations', () => {
   });
 
   it('loader imports and returns object when package is available', () => {
-    const HttpInstrumentation = function () {};
-    const loader = rewire('../src/instrumentations/loader');
-    const revert = loader.__set__('require', module => {
-      return { HttpInstrumentation };
-    });
+    const loader = require('../src/instrumentations/loader');
 
     const got = loader.load(
       '@opentelemetry/instrumentation-http',
       'HttpInstrumentation'
     );
-    assert.strictEqual(got, HttpInstrumentation);
 
-    revert();
+    assert.strictEqual(got, HttpInstrumentation);
   });
 });


### PR DESCRIPTION
# Description

When `@splunk/otel` is npm linked, instrumentation loader cannot find the instrumentation packages installed in the main module and causes issues hard to debug.

This PR makes it so the loader first tries to load the instrumentations form the perspective of the main module(the expected behavior) and then falls back to the naive require which happens to behave the same way when `@splunk/otel` is not linked.

Another scenario that it fixes is when your dep tree looks something like this:

```
your/app
├─┬ metapackage
│ ├── instrumentation1
│ └── instrumentation2
└── @splunk/otel
```

Since `require` is called from the context of `@splunk/otel` none of the instrumentations are present from the context of our distro. Only if npm flattens the tree, they are.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Internal change (a change which is not visible to the package consumers)

# How Has This Been Tested?

- [x] Tested manually
- [x] Added automated tests

# Checklist:

- [x] Unit tests have been added/updated
- [x] Change file has been generated (`npm run change:new`)
- [ ] Delete this branch (after the PR is merged)
