### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,6 +2,103 @@
   "name": "@splunk/otel",
   "entries": [
     {
+      "date": "Fri, 03 Jun 2022 13:48:20 GMT",
+      "tag": "@splunk/otel_v1.0.0",
+      "version": "1.0.0",
+      "comments": {
+        "major": [
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "f2ed1b9497e8eb30a4192e1c6d1b631f4564b5b6",
+            "comment": "chore: remove support for deprecated `opentelemetry-instrumentation-amqplib`"
+          },
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "fc7b002cdb61cf4ace5b73449c1ef69124ec0b44",
+            "comment": "chore: remove support for deprecated `opentelemetry-instrumentation-aws-sdk`"
+          },
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "2df2a1e4ae1d36c7f02a2d79f3210fd70e6db52b",
+            "comment": "feat: throw when `startTracing` is called twice"
+          },
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "070c6d658321e064e0bddcdc9611002537af1f35",
+            "comment": "feat: throw when extraneous properties are provided"
+          },
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "5b4322d1e5c63c98be116a9ddc2d9f1b741fab24",
+            "comment": "chore: remove support for Node versions before LTS 12"
+          },
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "c01f78af6dfa2fced801c128bad7dbf58ed58b1a",
+            "comment": "feat: upgrade OTel deps and bump min instrumentation versions"
+          }
+        ],
+        "minor": [
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "25a24ac055e479ddd330d15820ab800293df94e9",
+            "comment": "feat: prebuild for node@18"
+          },
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "d5ae0644a042424324c30188986324306af0cd0f",
+            "comment": "feat: add splunk.distro.version resource attribute"
+          },
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "57b3dd05bc93b054f023bf828786d5319da91961",
+            "comment": "feat: bring in detectors for os.* and host.* attributes"
+          },
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "499f54f65ffa601bbcd955f3d212c9e4763cda57",
+            "comment": "feat: add a generic start API"
+          },
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "638b774ac52d8d5475359d1d036b24fa38726749",
+            "comment": "feat: detect resource from process"
+          },
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "7a7ef91e2ff7a1aaa8184608b900cb9e16f63598",
+            "comment": "feat: throw when unexpected configuration provided"
+          },
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "4fd1655b8373fe052116a72ab15b96b8852ba8bd",
+            "comment": "feat: implement setting up ConsoleSpanExporter via env var"
+          }
+        ],
+        "none": [
+          {
+            "author": "rauno56@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "11df6ddb01885b0c60d9eab8ed5671a8d29a3ab6",
+            "comment": "feat: change the `readme.md` badge to stable"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 21 Apr 2022 17:01:07 GMT",
       "tag": "@splunk/otel_v0.18.0",
       "version": "0.18.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,31 @@
 # Change Log - @splunk/otel
 
-This log was last generated on Thu, 21 Apr 2022 17:01:07 GMT and should not be manually modified.
+This log was last generated on Fri, 03 Jun 2022 13:48:20 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 1.0.0
+
+Fri, 03 Jun 2022 13:48:20 GMT
+
+### Major changes
+
+- chore: remove support for deprecated `opentelemetry-instrumentation-amqplib` (rauno56@gmail.com)
+- chore: remove support for deprecated `opentelemetry-instrumentation-aws-sdk` (rauno56@gmail.com)
+- feat: throw when `startTracing` is called twice (rauno56@gmail.com)
+- feat: throw when extraneous properties are provided (rauno56@gmail.com)
+- chore: remove support for Node versions before LTS 12 (rauno56@gmail.com)
+- feat: upgrade OTel deps and bump min instrumentation versions (rauno56@gmail.com)
+
+### Minor changes
+
+- feat: prebuild for node@18 (rauno56@gmail.com)
+- feat: add splunk.distro.version resource attribute (rauno56@gmail.com)
+- feat: bring in detectors for os.* and host.* attributes (rauno56@gmail.com)
+- feat: add a generic start API (rauno56@gmail.com)
+- feat: detect resource from process (rauno56@gmail.com)
+- feat: throw when unexpected configuration provided (rauno56@gmail.com)
+- feat: implement setting up ConsoleSpanExporter via env var (rauno56@gmail.com)
 
 ## 0.18.0
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <img alt="npm" src="https://img.shields.io/npm/v/@splunk/otel?style=for-the-badge">
   <img alt="node-current" src="https://img.shields.io/node/v/@splunk/otel?style=for-the-badge">
   <img alt="Codecov" src="https://img.shields.io/codecov/c/github/signalfx/splunk-otel-js?style=for-the-badge&token=XKXjEQKGaK">
-  <img alt="GitHub branch checks state" src="https://img.shields.io/github/checks-status/signalfx/splunk-otel-js/main?style=for-the-badge">
+  <img alt="GitHub branch checks state" src="https://img.shields.io/github/workflow/status/signalfx/splunk-otel-js/Continuous%20Integration/main?style=for-the-badge">
 </p>
 
 # Splunk Distribution of OpenTelemetry for Node.js
@@ -111,7 +111,7 @@ startTracing({
 });
 ```
 
-> `startTracing` is destructive to Open Telemetry API globals. We provide the `stopTracing` method, but it won't revert to OTel API globals set before `startTracing` was run, it will only disable globals, which `startTracing` set.
+> `startTracing` is destructive to Open Telemetry API globals. Any globals set before running `startTracing` are overwritten.
 
 ## Default Instrumentation Packages<a name="default-instrumentation-packages"></a>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img alt="Beta" src="https://img.shields.io/badge/status-beta-informational?style=for-the-badge">
+  <img alt="Stable" src="https://img.shields.io/badge/status-stable-informational?style=for-the-badge">
   <a href="https://github.com/signalfx/splunk-otel-js/releases">
     <img alt="GitHub release (latest by date)" src="https://img.shields.io/github/v/release/signalfx/splunk-otel-js?include_prereleases&style=for-the-badge">
   </a>

--- a/change/@splunk-otel-42417487-cc55-467d-b741-9e94bb35bb9e.json
+++ b/change/@splunk-otel-42417487-cc55-467d-b741-9e94bb35bb9e.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: implement setting up ConsoleSpanExporter via env var",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@splunk-otel-664a01b7-34ea-48bf-a30a-cf272a2d0402.json
+++ b/change/@splunk-otel-664a01b7-34ea-48bf-a30a-cf272a2d0402.json
@@ -1,7 +1,0 @@
-{
-  "type": "major",
-  "comment": "feat: upgrade OTel deps and bump min instrumentation versions",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@splunk-otel-720ca615-45a6-44a5-832e-ac1622535e24.json
+++ b/change/@splunk-otel-720ca615-45a6-44a5-832e-ac1622535e24.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: prebuild for node@18",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@splunk-otel-7380d88c-bd30-4b35-aa18-8cc7a6b9192e.json
+++ b/change/@splunk-otel-7380d88c-bd30-4b35-aa18-8cc7a6b9192e.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: add splunk.distro.version resource attribute",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@splunk-otel-78671426-1296-47f4-bc37-ca6089c4d441.json
+++ b/change/@splunk-otel-78671426-1296-47f4-bc37-ca6089c4d441.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: bring in detectors for os.* and host.* attributes",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@splunk-otel-835859df-2920-4280-93ed-07aba289641d.json
+++ b/change/@splunk-otel-835859df-2920-4280-93ed-07aba289641d.json
@@ -1,6 +1,6 @@
 {
   "type": "major",
-  "comment": "chore: remove support for `opentelemetry-instrumentation-amqplib`",
+  "comment": "chore: remove support for deprecated `opentelemetry-instrumentation-amqplib`",
   "packageName": "@splunk/otel",
   "email": "rauno56@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@splunk-otel-835859df-2920-4280-93ed-07aba289641d.json
+++ b/change/@splunk-otel-835859df-2920-4280-93ed-07aba289641d.json
@@ -1,7 +1,0 @@
-{
-  "type": "major",
-  "comment": "chore: remove support for deprecated `opentelemetry-instrumentation-amqplib`",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@splunk-otel-acb2dc51-51a5-46ca-98e5-6800ba8497b6.json
+++ b/change/@splunk-otel-acb2dc51-51a5-46ca-98e5-6800ba8497b6.json
@@ -1,7 +1,0 @@
-{
-  "type": "major",
-  "comment": "feat: throw when `startTracing` is called twice",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@splunk-otel-b10e9b93-358f-4659-a0ae-6238abb6116c.json
+++ b/change/@splunk-otel-b10e9b93-358f-4659-a0ae-6238abb6116c.json
@@ -1,7 +1,0 @@
-{
-  "type": "major",
-  "comment": "feat: throw when extraneous properties are provided",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@splunk-otel-b10e9b93-358f-4659-a0ae-6238abb6116c.json
+++ b/change/@splunk-otel-b10e9b93-358f-4659-a0ae-6238abb6116c.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat: throw when extraneous properties are provided",
+  "packageName": "@splunk/otel",
+  "email": "rauno56@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@splunk-otel-b97ec2d2-5809-4cf8-89ee-0dde69350680.json
+++ b/change/@splunk-otel-b97ec2d2-5809-4cf8-89ee-0dde69350680.json
@@ -1,6 +1,6 @@
 {
   "type": "major",
-  "comment": "fix: remove opentelemetry-instrumentation-aws-sdk from autoloaded instrumentations",
+  "comment": "chore: remove support for deprecated `opentelemetry-instrumentation-aws-sdk`",
   "packageName": "@splunk/otel",
   "email": "rauno56@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@splunk-otel-b97ec2d2-5809-4cf8-89ee-0dde69350680.json
+++ b/change/@splunk-otel-b97ec2d2-5809-4cf8-89ee-0dde69350680.json
@@ -1,7 +1,0 @@
-{
-  "type": "major",
-  "comment": "chore: remove support for deprecated `opentelemetry-instrumentation-aws-sdk`",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@splunk-otel-b99ffa99-f72c-4906-bfe8-2ab9119626ae.json
+++ b/change/@splunk-otel-b99ffa99-f72c-4906-bfe8-2ab9119626ae.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: add a generic start API",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@splunk-otel-c1f5d9c4-8f57-4d27-a88c-bebce002f03a.json
+++ b/change/@splunk-otel-c1f5d9c4-8f57-4d27-a88c-bebce002f03a.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: detect resource from process",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@splunk-otel-d8cc588a-a981-4d72-90a6-4fd68f98cb00.json
+++ b/change/@splunk-otel-d8cc588a-a981-4d72-90a6-4fd68f98cb00.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "feat: change the `readme.md` badge to stable",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "none"
-}

--- a/change/@splunk-otel-d8cc588a-a981-4d72-90a6-4fd68f98cb00.json
+++ b/change/@splunk-otel-d8cc588a-a981-4d72-90a6-4fd68f98cb00.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "feat: change the `readme.md` badge to stable",
+  "packageName": "@splunk/otel",
+  "email": "rauno56@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@splunk-otel-f3b2f067-abed-4f03-9116-9db66c560941.json
+++ b/change/@splunk-otel-f3b2f067-abed-4f03-9116-9db66c560941.json
@@ -1,7 +1,0 @@
-{
-  "type": "major",
-  "comment": "chore: remove support for Node versions before LTS 12",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@splunk-otel-f9a678c1-47b2-43b4-a3cd-52470d587002.json
+++ b/change/@splunk-otel-f9a678c1-47b2-43b4-a3cd-52470d587002.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: throw when unexpected configuration provided",
-  "packageName": "@splunk/otel",
-  "email": "rauno56@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/instrumentation-http": "^0.28.0",
-    "@splunk/otel": "^1.0.0",
+    "@splunk/otel": "^0.18.0",
     "axios": "^0.21.1",
     "express": "^4.17.1"
   }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/instrumentation-http": "^0.28.0",
-    "@splunk/otel": "^0.17.0",
+    "@splunk/otel": "^1.0.0",
     "axios": "^0.21.1",
     "express": "^4.17.1"
   }

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation-express": "^0.29.0",
     "@opentelemetry/instrumentation-http": "^0.28.0",
-    "@splunk/otel": "^1.0.0",
+    "@splunk/otel": "^0.18.0",
     "axios": "^0.21.1",
     "env-cmd": "^10.1.0",
     "express": "^4.17.1",

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation-express": "^0.29.0",
     "@opentelemetry/instrumentation-http": "^0.28.0",
-    "@splunk/otel": "^0.17.0",
+    "@splunk/otel": "^1.0.0",
     "axios": "^0.21.1",
     "env-cmd": "^10.1.0",
     "express": "^4.17.1",

--- a/examples/log-injection/package.json
+++ b/examples/log-injection/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/instrumentation-pino": "^0.29.0",
-    "@splunk/otel": "^1.0.0",
+    "@splunk/otel": "^0.18.0",
     "pino": "^6.13.3"
   }
 }

--- a/examples/log-injection/package.json
+++ b/examples/log-injection/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/instrumentation-pino": "^0.29.0",
-    "@splunk/otel": "^0.17.0",
+    "@splunk/otel": "^1.0.0",
     "pino": "^6.13.3"
   }
 }

--- a/examples/logs/package.json
+++ b/examples/logs/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
-    "@splunk/otel": "^1.0.0"
+    "@splunk/otel": "^0.18.0"
   }
 }

--- a/examples/logs/package.json
+++ b/examples/logs/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
-    "@splunk/otel": "^0.17.0"
+    "@splunk/otel": "^1.0.0"
   }
 }

--- a/examples/mixed/package.json
+++ b/examples/mixed/package.json
@@ -9,7 +9,7 @@
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/instrumentation-http": "^0.28.0",
     "@opentelemetry/instrumentation-pino": "^0.29.0",
-    "@splunk/otel": "^0.17.0",
+    "@splunk/otel": "^1.0.0",
     "pino": "^6.13.2"
   }
 }

--- a/examples/mixed/package.json
+++ b/examples/mixed/package.json
@@ -9,7 +9,7 @@
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/instrumentation-http": "^0.28.0",
     "@opentelemetry/instrumentation-pino": "^0.29.0",
-    "@splunk/otel": "^1.0.0",
+    "@splunk/otel": "^0.18.0",
     "pino": "^6.13.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "0.18.0",
+  "version": "1.0.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { inspect } from 'util';
-
 import { context, diag } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
 import { collectMemoryInfo, MemoryInfo } from './memory';
@@ -92,12 +90,7 @@ export const allowedMetricsOptions = [
 ];
 
 export function startMetrics(opts: StartMetricsOptions = {}) {
-  try {
-    assertNoExtraneousProperties(opts, allowedMetricsOptions);
-  } catch (e) {
-    diag.error(inspect(e));
-    diag.warn('This will turn into a thrown exception in @splunk/otel@1.0');
-  }
+  assertNoExtraneousProperties(opts, allowedMetricsOptions);
 
   const options = _setDefaultOptions(opts);
 

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { inspect } from 'util';
-
 import { context, diag } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
 import {
@@ -55,12 +53,7 @@ function extCollectSamples(extension: ProfilingExtension) {
 }
 
 export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
-  try {
-    assertNoExtraneousProperties(opts, allowedProfilingOptions);
-  } catch (e) {
-    diag.error(inspect(e));
-    diag.warn('This will turn into a thrown exception in @splunk/otel@1.0');
-  }
+  assertNoExtraneousProperties(opts, allowedProfilingOptions);
 
   const options = _setDefaultOptions(opts);
 

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-import { inspect } from 'util';
 import { strict as assert } from 'assert';
 import { gte } from 'semver';
 
-import { context, propagation, trace, diag } from '@opentelemetry/api';
+import { context, propagation, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import {
@@ -51,12 +50,9 @@ export { Options as TracingOptions };
 export function startTracing(opts: Partial<Options> = {}): boolean {
   assert(!isStarted || allowDoubleStart, 'Splunk APM already started');
   isStarted = true;
-  try {
-    assertNoExtraneousProperties(opts, allowedTracingOptions);
-  } catch (e) {
-    diag.error(inspect(e));
-    diag.warn('This will turn into a thrown exception in @splunk/otel@1.0');
-  }
+
+  assertNoExtraneousProperties(opts, allowedTracingOptions);
+
   const options = _setDefaultOptions(opts);
 
   // propagator

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '0.18.0';
+export const VERSION = '1.0.0';


### PR DESCRIPTION
# Description

- [x] Drop official support for legacy node versions 8 and 10. We know that OTel is dropping them very soon, we might as well do it now to avoid another major bump right after GA.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Internal change (a change which is not visible to the package consumers)
- [ ] Documentation change or requires a documentation update

# How Has This Been Tested?

- [ ] Tested manually
- [ ] Added automated tests

# Checklist:

- [x] Unit tests have been added/updated
- [ ] Documentation has been updated
- [x] Change file has been generated (`npm run change:new`)
- [ ] Delete this branch (after the PR is merged)
