### PR TITLE
feat: throw when unexpected configuration provided

### DIFF
--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -17,15 +17,20 @@
 import { context, diag } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
 import { collectMemoryInfo, MemoryInfo } from './memory';
-import { defaultServiceName, getEnvNumber } from '../utils';
+import {
+  assertNoExtraneousProperties,
+  defaultServiceName,
+  getEnvNumber,
+} from '../utils';
 import { detect as detectResource } from '../resource';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import * as signalfx from 'signalfx';
 
 export interface MetricsOptions {
-  serviceName: string;
   accessToken: string;
   endpoint: string;
+  serviceName: string;
+  // Metrics-specific configuration options:
   exportInterval: number;
 }
 
@@ -76,7 +81,22 @@ export type StartMetricsOptions = Partial<MetricsOptions> & {
   signalfx?: Partial<SignalFxOptions>;
 };
 
+export const allowedMetricsOptions = [
+  'accessToken',
+  'endpoint',
+  'exportInterval',
+  'serviceName',
+  'signalfx',
+];
+
 export function startMetrics(opts: StartMetricsOptions = {}) {
+  try {
+    assertNoExtraneousProperties(opts, allowedMetricsOptions);
+  } catch (e) {
+    console.warn(e);
+    console.warn('This will turn into a thrown exception in @splunk/otel@1.0');
+  }
+
   const options = _setDefaultOptions(opts);
 
   const signalFxClient = options.sfxClient;

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -16,7 +16,11 @@
 
 import { context, diag } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
-import { defaultServiceName, getEnvNumber } from '../utils';
+import {
+  assertNoExtraneousProperties,
+  defaultServiceName,
+  getEnvNumber,
+} from '../utils';
 import { detect as detectResource } from '../resource';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import {
@@ -24,6 +28,7 @@ import {
   ProfilingExtension,
   ProfilingOptions,
   ProfilingStartOptions,
+  allowedProfilingOptions,
 } from './types';
 import { ProfilingContextManager } from './profiling_contextmanager';
 import { OTLPProfilingExporter } from './otlp_exporter';
@@ -48,6 +53,13 @@ function extCollectSamples(extension: ProfilingExtension) {
 }
 
 export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
+  try {
+    assertNoExtraneousProperties(opts, allowedProfilingOptions);
+  } catch (e) {
+    console.warn(e);
+    console.warn('This will turn into a thrown exception in @splunk/otel@1.0');
+  }
+
   const options = _setDefaultOptions(opts);
 
   const extension = loadExtension();

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -44,14 +44,24 @@ export interface ProfilingExtension {
 }
 
 export interface ProfilingOptions {
-  serviceName: string;
   endpoint: string;
+  serviceName: string;
+  // Profiling-specific configuration options:
   callstackInterval: number;
   collectionDuration: number;
-  resource: Resource;
   debugExport: boolean;
+  resource: Resource;
 }
 
 export interface ProfilingExporter {
   send(profile: ProfilingData): void;
 }
+
+export const allowedProfilingOptions = [
+  'callstackInterval',
+  'collectionDuration',
+  'debugExport',
+  'endpoint',
+  'resource',
+  'serviceName',
+];

--- a/src/start.ts
+++ b/src/start.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseEnvBooleanString } from './utils';
+import { assertNoExtraneousProperties, parseEnvBooleanString } from './utils';
 import { startMetrics, MetricsOptions } from './metrics';
 import { startProfiling, ProfilingOptions } from './profiling';
 import { startTracing, stopTracing, TracingOptions } from './tracing';
@@ -22,7 +22,7 @@ interface Options {
   accessToken: string;
   endpoint: string;
   serviceName: string;
-  // Signal specific configuration options:
+  // Signal-specific configuration options:
   metrics: boolean | MetricsOptions;
   profiling: boolean | ProfilingOptions;
   tracing: boolean | TracingOptions;
@@ -41,6 +41,12 @@ export const start = (options: Partial<Options> = {}) => {
     throw new Error('Splunk APM already started');
   }
   const { metrics, profiling, tracing, ...restOptions } = options;
+
+  assertNoExtraneousProperties(restOptions, [
+    'endpoint',
+    'serviceName',
+    'accessToken',
+  ]);
 
   if (isSignalEnabled(options.profiling, 'SPLUNK_PROFILER_ENABLED', false)) {
     runningProfiling = startProfiling(

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -18,9 +18,10 @@ import { context, propagation, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 
+import { assertNoExtraneousProperties } from '../utils';
 import { configureHttpInstrumentation } from '../instrumentations/http';
 import { configureLogInjection } from '../instrumentations/logging';
-import { Options, _setDefaultOptions } from './options';
+import { allowedTracingOptions, Options, _setDefaultOptions } from './options';
 import { gte } from 'semver';
 import {
   AsyncHooksContextManager,
@@ -32,6 +33,12 @@ let unregisterInstrumentations: (() => void) | null = null;
 
 export { Options as TracingOptions };
 export function startTracing(opts: Partial<Options> = {}): boolean {
+  try {
+    assertNoExtraneousProperties(opts, allowedTracingOptions);
+  } catch (e) {
+    console.warn(e);
+    console.warn('This will turn into a thrown exception in @splunk/otel@1.0');
+  }
   const options = _setDefaultOptions(opts);
 
   // propagator

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// TODO: use assert.strict once we deprecate node@8
+import * as assert from 'assert';
+
 export const defaultServiceName = 'unnamed-node-service';
 
 export function parseEnvBooleanString(value?: string) {
@@ -61,4 +65,30 @@ export function getEnvNumber(key: string, defaultValue: number): number {
   }
 
   return numberValue;
+}
+
+export function deduplicate(arr: string[]) {
+  return [...new Set(arr)];
+}
+
+const formatStringSet = (set: Set<string> | string[]) => {
+  return [...set.values()].map(item => `"${item}"`).join(', ');
+};
+
+export function assertNoExtraneousProperties(
+  obj: Record<string, any>,
+  expectedProps: string[]
+) {
+  const keys = new Set(Object.keys(obj));
+  for (const p of expectedProps) {
+    keys.delete(p);
+  }
+
+  assert.equal(
+    keys.size,
+    0,
+    `Unexpected configuration options: ${formatStringSet(
+      keys
+    )}. Allowed: ${formatStringSet(expectedProps)}`
+  );
 }


### PR DESCRIPTION
# Description

I've accountered myself a situation where I think I specify a configuration option, but it does not go into effect because I've mistyped it. This feature catches those in bootup.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Internal change (a change which is not visible to the package consumers)
- [ ] Documentation change or requires a documentation update

# How Has This Been Tested?

- [ ] Tested manually
- [ ] Added automated tests

# Checklist:

- [ ] Unit tests have been added/updated
- [ ] Documentation has been updated
- [ ] Change file has been generated (`npm run change:new`)
- [ ] Delete this branch (after the PR is merged)
