### PR TITLE
chore: remove support for older Node versions than LTS 12

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -40,9 +40,8 @@ open an issue in GitHub. Any and all ideas for improvements are also welcome.
 
 ## Requirements
 
-This Splunk Distribution of OpenTelemetry requires Node.js 8.5 or higher,
+This Splunk Distribution of OpenTelemetry requires Node.js v12.13 or higher,
 [see more information here](https://github.com/open-telemetry/opentelemetry-js#node-support)
-If you're still using an earlier version of Node.js, continue using the SignalFx Tracing Library for Node.js.
 
 Current effective required Node.js version is: ![node-current](https://img.shields.io/node/v/@splunk/otel?style=flat-square)
 

--- a/change/@splunk-otel-f3b2f067-abed-4f03-9116-9db66c560941.json
+++ b/change/@splunk-otel-f3b2f067-abed-4f03-9116-9db66c560941.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "chore: remove support for Node versions before LTS 12",
+  "packageName": "@splunk/otel",
+  "email": "rauno56@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "stats"
   ],
   "engines": {
-    "node": ">=8.5.0 <18"
+    "node": ">=12.13"
   },
   "files": [
     "binding.gyp",


### PR DESCRIPTION
# Description

Drop official support for `node@8` and `node@10`. Will leave the builds and testing for now as an indicator to when we are actually starting to break for those versions.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Internal change (a change which is not visible to the package consumers)
- [x] Documentation change or requires a documentation update

# Checklist:

- [x] Documentation has been updated
- [ ] Change file has been generated (`npm run change:new`)
- [ ] Delete this branch (after the PR is merged)
