### PR TITLE
fix: remove Aspecto's aws sdk instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ any of these instrumentations, you'll need to install them with npm and then run
 * `@opentelemetry/instrumentation-tedious`
 * `@opentelemetry/instrumentation-winston`
 * `opentelemetry-instrumentation-amqplib`
-* `opentelemetry-instrumentation-aws-sdk`
 * `opentelemetry-instrumentation-elasticsearch`
 * `opentelemetry-instrumentation-kafkajs`
 * `opentelemetry-instrumentation-mongoose`

--- a/change/@splunk-otel-b97ec2d2-5809-4cf8-89ee-0dde69350680.json
+++ b/change/@splunk-otel-b97ec2d2-5809-4cf8-89ee-0dde69350680.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "fix: remove opentelemetry-instrumentation-aws-sdk from autoloaded instrumentations",
+  "packageName": "@splunk/otel",
+  "email": "rauno56@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
     "@opentelemetry/instrumentation-tedious": ">=0.1.0 <1",
     "@opentelemetry/instrumentation-winston": ">=0.25.0 <1",
     "opentelemetry-instrumentation-amqplib": ">=0.25.0 <1",
-    "opentelemetry-instrumentation-aws-sdk": ">=0.25.0 <1",
     "opentelemetry-instrumentation-elasticsearch": ">=0.25.0 <1",
     "opentelemetry-instrumentation-kafkajs": ">=0.25.0 <1",
     "opentelemetry-instrumentation-mongoose": ">=0.25.0 <1",
@@ -252,9 +251,6 @@
       "optional": true
     },
     "opentelemetry-instrumentation-amqplib": {
-      "optional": true
-    },
-    "opentelemetry-instrumentation-aws-sdk": {
       "optional": true
     },
     "opentelemetry-instrumentation-elasticsearch": {

--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -57,7 +57,6 @@ const supportedInstrumentations: [string, string][] = [
   ['@opentelemetry/instrumentation-tedious', 'TediousInstrumentation'],
   ['@opentelemetry/instrumentation-winston', 'WinstonInstrumentation'],
   ['opentelemetry-instrumentation-amqplib', 'AmqplibInstrumentation'],
-  ['opentelemetry-instrumentation-aws-sdk', 'AwsInstrumentation'],
   [
     'opentelemetry-instrumentation-elasticsearch',
     'ElasticsearchInstrumentation',

--- a/test/instrumentations.test.ts
+++ b/test/instrumentations.test.ts
@@ -41,7 +41,7 @@ describe('instrumentations', () => {
     const loadStub = sinon.stub(loader, 'load');
     try {
       const inst = instrumentations.getInstrumentations();
-      sinon.assert.callCount(loadStub, 38);
+      sinon.assert.callCount(loadStub, 37);
     } finally {
       loadStub.reset();
       loadStub.restore();


### PR DESCRIPTION
# Description

All other supported instrumentation versions depend on `@opentelemetry/instrumentation@0.27` or later. Aspectos AWS SDK instrumentation is depending on the older one and will never be updated because it's now moved over to OTel repo.
Different versions of `@opentelemetry/instrumentation` certainly break for stricter TS compilations and possibly cause issues in meta-packages, autoloaders or when packages are hoisted in monorepos.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Internal change (a change which is not visible to the package consumers)
- [ ] Documentation change or requires a documentation update

# Checklist:

- [x] Unit tests have been added/updated
- [ ] Documentation has been updated
- [x] Change file has been generated (`npm run change:new`)
- [ ] Delete this branch (after the PR is merged)
