### PR TITLE
test: add a few smoke tests for profiling

### DIFF
--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -24,6 +24,7 @@ import {
 import { detect as detectResource } from '../resource';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import {
+  ProfilingExporter,
   ProfilingExtension,
   ProfilingOptions,
   ProfilingStartOptions,
@@ -51,6 +52,24 @@ function extCollectSamples(extension: ProfilingExtension) {
   return extension.collect();
 }
 
+export function defaultExporterFactory(
+  options: ProfilingOptions
+): ProfilingExporter[] {
+  const exporters: ProfilingExporter[] = [
+    new OTLPProfilingExporter({
+      endpoint: options.endpoint,
+      callstackInterval: options.callstackInterval,
+      resource: options.resource,
+    }),
+  ];
+
+  if (options.debugExport) {
+    exporters.push(new DebugExporter());
+  }
+
+  return exporters;
+}
+
 export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
   assertNoExtraneousProperties(opts, allowedProfilingOptions);
 
@@ -68,17 +87,7 @@ export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
   contextManager.enable();
   context.setGlobalContextManager(contextManager);
 
-  const exporters = options.exporters ?? [
-    new OTLPProfilingExporter({
-      endpoint: options.endpoint,
-      callstackInterval: options.callstackInterval,
-      resource: options.resource,
-    }),
-  ];
-
-  if (options.debugExport) {
-    exporters.push(new DebugExporter());
-  }
+  const exporters = options.exporterFactory(options);
 
   const startOptions = {
     samplingIntervalMicroseconds: options.callstackInterval * 1_000,
@@ -162,6 +171,6 @@ export function _setDefaultOptions(
     collectionDuration: options.collectionDuration || 30_000,
     resource,
     debugExport: options.debugExport ?? false,
-    exporters: options.exporters,
+    exporterFactory: options.exporterFactory ?? defaultExporterFactory,
   };
 }

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -24,7 +24,6 @@ import {
 import { detect as detectResource } from '../resource';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import {
-  ProfilingExporter,
   ProfilingExtension,
   ProfilingOptions,
   ProfilingStartOptions,
@@ -69,7 +68,7 @@ export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
   contextManager.enable();
   context.setGlobalContextManager(contextManager);
 
-  const exporters: ProfilingExporter[] = [
+  const exporters = options.exporters ?? [
     new OTLPProfilingExporter({
       endpoint: options.endpoint,
       callstackInterval: options.callstackInterval,
@@ -163,5 +162,6 @@ export function _setDefaultOptions(
     collectionDuration: options.collectionDuration || 30_000,
     resource,
     debugExport: options.debugExport ?? false,
+    exporters: options.exporters,
   };
 }

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -51,6 +51,7 @@ export interface ProfilingOptions {
   collectionDuration: number;
   debugExport: boolean;
   resource: Resource;
+  exporters?: ProfilingExporter[];
 }
 
 export interface ProfilingExporter {
@@ -64,4 +65,5 @@ export const allowedProfilingOptions = [
   'endpoint',
   'resource',
   'serviceName',
+  'exporters',
 ];

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -43,6 +43,10 @@ export interface ProfilingExtension {
   exitContext(context: unknown): void;
 }
 
+export type ProfilingExporterFactory = (
+  options: ProfilingOptions
+) => ProfilingExporter[];
+
 export interface ProfilingOptions {
   endpoint: string;
   serviceName: string;
@@ -51,7 +55,7 @@ export interface ProfilingOptions {
   collectionDuration: number;
   debugExport: boolean;
   resource: Resource;
-  exporters?: ProfilingExporter[];
+  exporterFactory: ProfilingExporterFactory;
 }
 
 export interface ProfilingExporter {
@@ -65,5 +69,5 @@ export const allowedProfilingOptions = [
   'endpoint',
   'resource',
   'serviceName',
-  'exporters',
+  'exporterFactory',
 ];

--- a/test/profiling/extension.test.ts
+++ b/test/profiling/extension.test.ts
@@ -66,6 +66,8 @@ describe('profiling native extension', () => {
       assert.equal(typeof stacktrace, 'string');
       assertNanoSecondString(timestamp);
 
+      // The first two lines are intentionally empty,
+      // as we don't have information about the thread state.
       const lines = stacktrace.split('\n');
       assert.deepStrictEqual(lines[0], '');
       assert.deepStrictEqual(lines[1], '');

--- a/test/profiling/extension.test.ts
+++ b/test/profiling/extension.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { hrtime } from 'process';
+import { ProfilingExtension } from '../../src/profiling/types';
+
+const extension: ProfilingExtension = require('../../src/native_ext').profiling;
+
+describe('profiling native extension', () => {
+  afterEach(() => {
+    extension.stop();
+  });
+
+  it('is possible to collect stacktraces', () => {
+    // Use a lower interval to make sure we capture something
+    extension.start({
+      samplingIntervalMicroseconds: 1_000,
+      recordDebugInfo: false,
+    });
+
+    function spin() {
+      let v = 0.0;
+
+      for (let i = 0; i < 10_000_000; i++) {
+        v += Math.random();
+      }
+
+      return v;
+    }
+
+    let durationNanos = 0;
+
+    // Spin for at least 10ms
+    while (durationNanos < 10 * 1e6) {
+      const begin = hrtime.bigint();
+      spin();
+      durationNanos += Number(hrtime.bigint() - begin);
+    }
+
+    const result = extension.collect();
+    // The types might not be what is declared in typescript, a sanity check.
+    assert.equal(typeof result, 'object');
+    const { stacktraces, startTimeNanos } = result;
+
+    assert(stacktraces.length >= 10);
+
+    for (const { stacktrace, timestamp } of stacktraces) {
+      // Don't bother checking for span and trace ID here.
+      assert.equal(typeof timestamp, 'string');
+      assert.equal(typeof stacktrace, 'string');
+
+      const lines = stacktrace.split('\n');
+      assert.deepStrictEqual(lines[0], '');
+      assert.deepStrictEqual(lines[1], '');
+      const stacklines = lines.slice(2, -1);
+
+      for (const stackline of stacklines) {
+        assert.match(stackline, /.+\(.+:\d+:\d+\)/);
+      }
+    }
+  });
+});

--- a/test/profiling/extension.test.ts
+++ b/test/profiling/extension.test.ts
@@ -69,7 +69,7 @@ describe('profiling native extension', () => {
       const stacklines = lines.slice(2, -1);
 
       for (const stackline of stacklines) {
-        assert(/.+\(.+:\d+:\d+\)/.test(stackline), stackline)
+        assert(/.+\(.+:\d+:\d+\)/.test(stackline), stackline);
       }
     }
   });

--- a/test/profiling/extension.test.ts
+++ b/test/profiling/extension.test.ts
@@ -53,7 +53,9 @@ describe('profiling native extension', () => {
     const { stacktraces, startTimeNanos } = result;
     assertNanoSecondString(startTimeNanos);
 
-    const expectedStacktraceCount = 9;
+    // Keep the expected count low, the first run of the profiler
+    // has stacktraces with variable timestamps.
+    const expectedStacktraceCount = 5;
     assert(
       stacktraces.length >= expectedStacktraceCount,
       `expected ${expectedStacktraceCount} stacktraces, got ${stacktraces.length}`

--- a/test/profiling/extension.test.ts
+++ b/test/profiling/extension.test.ts
@@ -45,7 +45,7 @@ describe('profiling native extension', () => {
       recordDebugInfo: false,
     });
 
-    spinMs(10);
+    spinMs(100);
 
     const result = extension.collect();
     // The types might not be what is declared in typescript, a sanity check.

--- a/test/profiling/extension.test.ts
+++ b/test/profiling/extension.test.ts
@@ -69,7 +69,7 @@ describe('profiling native extension', () => {
       const stacklines = lines.slice(2, -1);
 
       for (const stackline of stacklines) {
-        assert.match(stackline, /.+\(.+:\d+:\d+\)/);
+        assert.match(stackline, /.+\(.+:\d+:\d+\)/, stackline);
       }
     }
   });

--- a/test/profiling/extension.test.ts
+++ b/test/profiling/extension.test.ts
@@ -69,7 +69,7 @@ describe('profiling native extension', () => {
       const stacklines = lines.slice(2, -1);
 
       for (const stackline of stacklines) {
-        assert.match(stackline, /.+\(.+:\d+:\d+\)/, stackline);
+        assert(/.+\(.+:\d+:\d+\)/.test(stackline), stackline)
       }
     }
   });

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -95,7 +95,11 @@ describe('profiling', () => {
         // It might be possible all 10 stacktraces will not be available,
         // due to the first stacktraces having slightly offset timings
         // after a profiling run is started.
-        assert(stacktracesReceived >= 9);
+        const expectedStacktraces = 9;
+        assert(
+          stacktracesReceived >= 9,
+          `expected at least ${expectedStacktraces}, got ${stacktracesReceived}`
+        );
         // Stop flushes the exporters, hence the extra call count
         assert.deepStrictEqual(sendCallCount, 2);
         done();

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { hrtime } from 'process';
+import { startProfiling, _setDefaultOptions } from '../../src/profiling';
+import { ProfilingExporter, ProfilingData } from '../../src/profiling/types';
+import { detect as detectResource } from '../../src/resource';
+import { Resource } from '@opentelemetry/resources';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import * as utils from '../utils';
+
+describe('profiling', () => {
+  describe('options', () => {
+    beforeEach(() => {
+      utils.cleanEnvironment();
+    });
+
+    it('sets default options when no options are provided', () => {
+      const options = _setDefaultOptions();
+      assert.deepStrictEqual(options, {
+        serviceName: 'unnamed-node-service',
+        endpoint: 'localhost:4317',
+        callstackInterval: 1_000,
+        collectionDuration: 30_000,
+        debugExport: false,
+        resource: new Resource({
+          [SemanticResourceAttributes.SERVICE_NAME]: 'unnamed-node-service',
+        }).merge(detectResource()),
+        exporters: undefined,
+      });
+    });
+
+    it('uses options from environment', () => {
+      process.env.SPLUNK_PROFILER_LOGS_ENDPOINT = 'collector:4444';
+      process.env.OTEL_SERVICE_NAME = 'profiled-service';
+      process.env.SPLUNK_PROFILER_CALL_STACK_INTERVAL = '100';
+
+      const options = _setDefaultOptions();
+      assert.deepStrictEqual(options.serviceName, 'profiled-service');
+      assert.deepStrictEqual(options.endpoint, 'collector:4444');
+      assert.deepStrictEqual(options.callstackInterval, 100);
+    });
+
+    it('prefers user passed options over environment variables', () => {
+      process.env.SPLUNK_PROFILER_LOGS_ENDPOINT = 'collector:5555';
+      process.env.OTEL_SERVICE_NAME = 'profiled-service';
+      process.env.SPLUNK_PROFILER_CALL_STACK_INTERVAL = '200';
+
+      const options = _setDefaultOptions({
+        serviceName: 'foo',
+        endpoint: 'localhost:1111',
+        callstackInterval: 50,
+      });
+      assert.deepStrictEqual(options.serviceName, 'foo');
+      assert.deepStrictEqual(options.endpoint, 'localhost:1111');
+      assert.deepStrictEqual(options.callstackInterval, 50);
+    });
+  });
+
+  describe('startProfiling', () => {
+    it('exports stacktraces', done => {
+      let stacktracesReceived = 0;
+      let sendCallCount = 0;
+      const exporter: ProfilingExporter = {
+        send(profilingData: ProfilingData) {
+          const { stacktraces } = profilingData;
+          stacktracesReceived += stacktraces.length;
+          sendCallCount += 1;
+        },
+      };
+
+      const { stop } = startProfiling({
+        serviceName: 'slow-service',
+        callstackInterval: 100,
+        collectionDuration: 1_000,
+        exporters: [exporter],
+      });
+
+      setTimeout(() => {
+        stop();
+        assert(stacktracesReceived >= 10);
+        // Stop flushes the exporters, hence the extra call count
+        assert.deepStrictEqual(sendCallCount, 2);
+        done();
+      }, 1_100);
+    });
+  });
+});

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -93,11 +93,11 @@ describe('profiling', () => {
       setTimeout(() => {
         stop();
         // It might be possible all 10 stacktraces will not be available,
-        // due to the first stacktraces having slightly offset timings
+        // due to the first few stacktraces having random timings
         // after a profiling run is started.
-        const expectedStacktraces = 9;
+        const expectedStacktraces = 5;
         assert(
-          stacktracesReceived >= 9,
+          stacktracesReceived >= expectedStacktraces,
           `expected at least ${expectedStacktraces}, got ${stacktracesReceived}`
         );
         // Stop flushes the exporters, hence the extra call count

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -16,7 +16,11 @@
 
 import * as assert from 'assert';
 import { hrtime } from 'process';
-import { startProfiling, _setDefaultOptions } from '../../src/profiling';
+import {
+  defaultExporterFactory,
+  startProfiling,
+  _setDefaultOptions,
+} from '../../src/profiling';
 import { ProfilingExporter, ProfilingData } from '../../src/profiling/types';
 import { detect as detectResource } from '../../src/resource';
 import { Resource } from '@opentelemetry/resources';
@@ -40,7 +44,7 @@ describe('profiling', () => {
         resource: new Resource({
           [SemanticResourceAttributes.SERVICE_NAME]: 'unnamed-node-service',
         }).merge(detectResource()),
-        exporters: undefined,
+        exporterFactory: defaultExporterFactory,
       });
     });
 
@@ -87,7 +91,7 @@ describe('profiling', () => {
         serviceName: 'slow-service',
         callstackInterval: 50,
         collectionDuration: 1_000,
-        exporters: [exporter],
+        exporterFactory: () => [exporter],
       });
 
       setTimeout(() => {

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -85,14 +85,14 @@ describe('profiling', () => {
 
       const { stop } = startProfiling({
         serviceName: 'slow-service',
-        callstackInterval: 100,
+        callstackInterval: 50,
         collectionDuration: 1_000,
         exporters: [exporter],
       });
 
       setTimeout(() => {
         stop();
-        // It might be possible all 10 stacktraces will not be available,
+        // It might be possible all stacktraces will not be available,
         // due to the first few stacktraces having random timings
         // after a profiling run is started.
         const expectedStacktraces = 5;

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -92,7 +92,10 @@ describe('profiling', () => {
 
       setTimeout(() => {
         stop();
-        assert(stacktracesReceived >= 10);
+        // It might be possible all 10 stacktraces will not be available,
+        // due to the first stacktraces having slightly offset timings
+        // after a profiling run is started.
+        assert(stacktracesReceived >= 9);
         // Stop flushes the exporters, hence the extra call count
         assert.deepStrictEqual(sendCallCount, 2);
         done();


### PR DESCRIPTION
Verifies the types received from native extension and that profiling data is exported.

The logs exporter is not tested as we're about to throw it away anyway in favor of pprof.