### PR TITLE
feat: implement a way to collect unformatted stacktrace lines from profiler

### DIFF
--- a/change/@splunk-otel-345cf72a-5e0b-4e99-9034-dd82ede484b4.json
+++ b/change/@splunk-otel-345cf72a-5e0b-4e99-9034-dd82ede484b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add a way to collect unformatted profiling data",
+  "packageName": "@splunk/otel",
+  "email": "rauno56@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/native_ext/profiling.cpp
+++ b/src/native_ext/profiling.cpp
@@ -247,27 +247,19 @@ ActivationBin* ProfilingGetActivationBin(Profiling* profiling, int64_t binIndex)
 }
 
 SpanActivation* FindClosestActivation(Profiling* profiling, int64_t ts) {
-  SpanActivation sentinel;
-  sentinel.startTime = std::numeric_limits<int64_t>::min();
-  sentinel.endTime = std::numeric_limits<int64_t>::max();
-  SpanActivation* t = &sentinel;
-
+  SpanActivation* t = nullptr;
   ActivationBin* bin = ProfilingGetActivationBin(profiling, ActivationBinIndex(profiling, ts));
 
   while (bin) {
     for (int64_t i = 0; i < bin->count; i++) {
       SpanActivation* activation = &bin->activations[i];
       if (activation->startTime <= ts && ts <= activation->endTime) {
-        if (activation->startTime > t->startTime) {
+        if (!t || activation->startTime > t->startTime) {
           t = activation;
         }
       }
     }
     bin = bin->next;
-  }
-
-  if (t == &sentinel) {
-    return nullptr;
   }
 
   return t;


### PR DESCRIPTION
# Description

For pprof it's useful to start with informatted stacktraces. Implemented a way to export that format instead of parsing already formatted stacktrace strings.

This introduces a lot of code duplication which we can remove once we have implemented the pprof exporter.

Changes to `FindClosestActivation` were due to the compiler complaining(see https://github.com/signalfx/splunk-otel-js/pull/502/commits/4933e40f20d14985e645cc69f846820ccbe16d50) probably because the second occurrence made it so it wasn't inlined anymore. The previous implementation was arguably somewhat more elegant, but the current one removes any confusion for the compiler and the unused `endTime`. If there's a better way to approach this, let me know.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Internal change (a change which is not visible to the package consumers)

# How Has This Been Tested?

- [x] Added automated tests

# Checklist:

- [x] Unit tests have been added/updated
- [ ] Documentation has been updated
- [ ] Change file has been generated (`npm run change:new`)
- [ ] Delete this branch (after the PR is merged)
