### PR TITLE
fix: handle endpoint scheme for profiling exporter

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -76,6 +76,16 @@ The following config options can be set by passing them as arguments to `startTr
 
 \*: Overwritten default value
 
+### Profiling
+
+| Environment variable<br>``startProfiling()`` argument           | Default value           | Support | Notes
+| --------------------------------------------------------------- | ----------------------- | ------- | ---
+| `SPLUNK_PROFILER_ENABLED`                                       | `false`                 | Experimental | Enable continuous profiling. See [profiling documentation](profiling.md) for more information.
+| `SPLUNK_PROFILER_LOGS_ENDPOINT`<br>`endpoint`                   | `http://localhost:4317` | Experimental | The OTLP logs receiver endpoint used for profiling data.
+| `OTEL_SERVICE_NAME`<br>`serviceName`                            | `unnamed-node-service`  | Experimental | Service name of the application.
+| `OTEL_RESOURCE_ATTRIBUTES`                                      |                         | Stable  | Comma-separated list of resource attributes. <details><summary>Example</summary>`deployment.environment=demo,key2=val2`</details>
+
+
 ### Start all
 
 To control all [signals](https://github.com/open-telemetry/opentelemetry-specification/blob/70fecd2dcba505b3ac3a7cb1851f947047743d24/specification/glossary.md#signals) with one call `start()` API can be used:

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -82,7 +82,7 @@ The following config options can be set by passing them as arguments to `startTr
 | --------------------------------------------------------------- | ----------------------- | ------- | ---
 | `SPLUNK_PROFILER_ENABLED`                                       | `false`                 | Experimental | Enable continuous profiling. See [profiling documentation](profiling.md) for more information.
 | `SPLUNK_PROFILER_LOGS_ENDPOINT`<br>`endpoint`                   | `http://localhost:4317` | Experimental | The OTLP logs receiver endpoint used for profiling data.
-| `OTEL_SERVICE_NAME`<br>`serviceName`                            | `unnamed-node-service`  | Experimental | Service name of the application.
+| `OTEL_SERVICE_NAME`<br>`serviceName`                            | `unnamed-node-service`  | Stable  | Service name of the application.
 | `OTEL_RESOURCE_ATTRIBUTES`                                      |                         | Stable  | Comma-separated list of resource attributes. <details><summary>Example</summary>`deployment.environment=demo,key2=val2`</details>
 
 

--- a/src/profiling/OTLPProfilingExporter.ts
+++ b/src/profiling/OTLPProfilingExporter.ts
@@ -34,7 +34,7 @@ interface LogsClient extends grpc.Client {
 
 function readContentSync(location: string): Buffer | undefined {
   try {
-    return fs.readFileSync(path.resolve(process.cwd(), location));
+    return fs.readFileSync(location);
   } catch (e) {
     diag.error(`Failed to read file at ${location}`, e);
   }

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -139,7 +139,7 @@ export function _setDefaultOptions(
   const endpoint =
     options.endpoint ||
     process.env.SPLUNK_PROFILER_LOGS_ENDPOINT ||
-    'localhost:4317';
+    'http://localhost:4317';
 
   const combinedResource = detectResource();
 

--- a/test/profiling/exporter.test.ts
+++ b/test/profiling/exporter.test.ts
@@ -27,7 +27,7 @@ describe('profiling OTLP exporter', () => {
       utils.cleanEnvironment();
     });
 
-    it('configures insecure gRPC credentials for endpoints without a sceme', () => {
+    it('configures insecure gRPC credentials for endpoints without a scheme', () => {
       const exporter = new OTLPProfilingExporter({
         endpoint: 'foobar:8181',
         callstackInterval: 1000,

--- a/test/profiling/exporter.test.ts
+++ b/test/profiling/exporter.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { OTLPProfilingExporter } from '../../src/profiling/OTLPProfilingExporter';
+import { Resource } from '@opentelemetry/resources';
+import * as utils from '../utils';
+import * as grpc from '@grpc/grpc-js';
+
+describe('profiling OTLP exporter', () => {
+  describe('configuration', () => {
+    beforeEach(() => {
+      utils.cleanEnvironment();
+    });
+
+    it('configures insecure gRPC credentials for endpoints without a sceme', () => {
+      const exporter = new OTLPProfilingExporter({
+        endpoint: 'foobar:8181',
+        callstackInterval: 1000,
+        resource: Resource.empty(),
+      });
+      assert.deepStrictEqual(
+        exporter['_client'].getChannel()['credentials'],
+        grpc.ChannelCredentials.createInsecure()
+      );
+    });
+
+    it('configures insecure gRPC credentials for http endpoints', () => {
+      const exporter = new OTLPProfilingExporter({
+        endpoint: 'http://foobar:8181',
+        callstackInterval: 1000,
+        resource: Resource.empty(),
+      });
+      assert.deepStrictEqual(
+        exporter['_client'].getChannel()['credentials'],
+        grpc.ChannelCredentials.createInsecure()
+      );
+    });
+
+    it('configures secure gRPC credentials for https endpoints', () => {
+      const exporter = new OTLPProfilingExporter({
+        endpoint: 'https://foobar:8181',
+        callstackInterval: 1000,
+        resource: Resource.empty(),
+      });
+      assert.deepStrictEqual(
+        exporter['_client'].getChannel()['credentials'],
+        grpc.ChannelCredentials.createSsl()
+      );
+    });
+  });
+});

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -37,7 +37,7 @@ describe('profiling', () => {
       const options = _setDefaultOptions();
       assert.deepStrictEqual(options, {
         serviceName: 'unnamed-node-service',
-        endpoint: 'localhost:4317',
+        endpoint: 'http://localhost:4317',
         callstackInterval: 1_000,
         collectionDuration: 30_000,
         debugExport: false,


### PR DESCRIPTION
Previously we only allowed endpoints without a scheme, but according to the OTel spec, `http` and `https` schemes must be handled.

Allowed values now:
* `host:port` - insecure gRPC credentials
* `http://host:port` - insecure gRPC credentials
* `https://host:port` - secure gRPC credentials,  certs are loaded according to OTLP cert env vars