### PR TITLE
fix: avoid crashes with profiler double-stops + test tracing info

### DIFF
--- a/src/native_ext/profiling.cpp
+++ b/src/native_ext/profiling.cpp
@@ -846,13 +846,10 @@ void ProfilingReset(Profiling* profiling) {
 }
 
 NAN_METHOD(CollectProfilingData) {
+  info.GetReturnValue().SetNull();
   if (!profiling) {
-    info.GetReturnValue().SetNull();
     return;
   }
-
-  auto jsProfilingData = Nan::New<v8::Object>();
-  info.GetReturnValue().Set(jsProfilingData);
 
   char prevTitle[64];
   ProfileTitle(profiling, prevTitle, sizeof(prevTitle));
@@ -868,6 +865,12 @@ NAN_METHOD(CollectProfilingData) {
 
   v8::CpuProfile* profile =
     profiling->profiler->StopProfiling(Nan::New(prevTitle).ToLocalChecked());
+  if (!profile) {
+    return;
+  }
+
+  auto jsProfilingData = Nan::New<v8::Object>();
+  info.GetReturnValue().Set(jsProfilingData);
 
   ProfilingBuildStacktraces(profiling, profile, jsProfilingData);
   ProfilingRecordDebugInfo(profiling, jsProfilingData);
@@ -879,13 +882,10 @@ NAN_METHOD(CollectProfilingData) {
 }
 
 NAN_METHOD(CollectProfilingDataRaw) {
+  info.GetReturnValue().SetNull();
   if (!profiling) {
-    info.GetReturnValue().SetNull();
     return;
   }
-
-  auto jsProfilingData = Nan::New<v8::Object>();
-  info.GetReturnValue().Set(jsProfilingData);
 
   char prevTitle[64];
   ProfileTitle(profiling, prevTitle, sizeof(prevTitle));
@@ -901,6 +901,12 @@ NAN_METHOD(CollectProfilingDataRaw) {
 
   v8::CpuProfile* profile =
     profiling->profiler->StopProfiling(Nan::New(prevTitle).ToLocalChecked());
+  if (!profile) {
+    return;
+  }
+
+  auto jsProfilingData = Nan::New<v8::Object>();
+  info.GetReturnValue().Set(jsProfilingData);
 
   ProfilingBuildRawStacktraces(profiling, profile, jsProfilingData);
   ProfilingRecordDebugInfo(profiling, jsProfilingData);
@@ -912,18 +918,21 @@ NAN_METHOD(CollectProfilingDataRaw) {
 }
 
 NAN_METHOD(StopProfiling) {
+  info.GetReturnValue().SetNull();
   if (!profiling) {
-    info.GetReturnValue().SetNull();
     return;
   }
-
-  auto jsProfilingData = Nan::New<v8::Object>();
-  info.GetReturnValue().Set(jsProfilingData);
 
   char title[64];
   ProfileTitle(profiling, title, sizeof(title));
 
   v8::CpuProfile* profile = profiling->profiler->StopProfiling(Nan::New(title).ToLocalChecked());
+  if (!profile) {
+    return;
+  }
+
+  auto jsProfilingData = Nan::New<v8::Object>();
+  info.GetReturnValue().Set(jsProfilingData);
 
   ProfilingBuildStacktraces(profiling, profile, jsProfilingData);
   ProfilingRecordDebugInfo(profiling, jsProfilingData);

--- a/src/native_ext/profiling.cpp
+++ b/src/native_ext/profiling.cpp
@@ -866,6 +866,9 @@ NAN_METHOD(CollectProfilingData) {
   v8::CpuProfile* profile =
     profiling->profiler->StopProfiling(Nan::New(prevTitle).ToLocalChecked());
   if (!profile) {
+    // profile with this title might've already be ended using a previous stop call
+    profiling->startTime = newStartTime;
+    profiling->wallStartTime = newWallStart;
     return;
   }
 
@@ -902,6 +905,9 @@ NAN_METHOD(CollectProfilingDataRaw) {
   v8::CpuProfile* profile =
     profiling->profiler->StopProfiling(Nan::New(prevTitle).ToLocalChecked());
   if (!profile) {
+    // profile with this title might've already be ended using a previous stop call
+    profiling->startTime = newStartTime;
+    profiling->wallStartTime = newWallStart;
     return;
   }
 
@@ -926,8 +932,10 @@ NAN_METHOD(StopProfiling) {
   char title[64];
   ProfileTitle(profiling, title, sizeof(title));
 
-  v8::CpuProfile* profile = profiling->profiler->StopProfiling(Nan::New(title).ToLocalChecked());
+  v8::CpuProfile* profile =
+    profiling->profiler->StopProfiling(Nan::New(title).ToLocalChecked());
   if (!profile) {
+    // profile with this title might've already be ended using a previous stop call
     return;
   }
 

--- a/src/native_ext/profiling.cpp
+++ b/src/native_ext/profiling.cpp
@@ -323,8 +323,8 @@ void V8StartProfiling(v8::CpuProfiler* profiler, const char* title) {
 #endif
 }
 
-void ProfileTitle(Profiling* profiling, char* buffer, size_t length) {
-  snprintf(buffer, length, "splunk-otel-js-%" PRId64, profiling->profilerSeq);
+void ProfileTitle(int64_t profilerSeq, char* buffer, size_t length) {
+  snprintf(buffer, length, "splunk-otel-js-%" PRId64, profilerSeq);
 }
 
 NAN_METHOD(StartProfiling) {
@@ -367,7 +367,7 @@ NAN_METHOD(StartProfiling) {
   profiling->profiler->SetSamplingInterval(samplingIntervalMicros);
 
   char title[64];
-  ProfileTitle(profiling, title, sizeof(title));
+  ProfileTitle(profiling->profilerSeq, title, sizeof(title));
 
   profiling->activationDepth = 0;
   profiling->startTime = HrTime();
@@ -852,10 +852,10 @@ NAN_METHOD(CollectProfilingData) {
   }
 
   char prevTitle[64];
-  ProfileTitle(profiling, prevTitle, sizeof(prevTitle));
+  ProfileTitle(profiling->profilerSeq, prevTitle, sizeof(prevTitle));
   profiling->profilerSeq++;
   char nextTitle[64];
-  ProfileTitle(profiling, nextTitle, sizeof(nextTitle));
+  ProfileTitle(profiling->profilerSeq, nextTitle, sizeof(nextTitle));
 
   profiling->activationDepth = 0;
   int64_t newStartTime = HrTime();
@@ -891,10 +891,10 @@ NAN_METHOD(CollectProfilingDataRaw) {
   }
 
   char prevTitle[64];
-  ProfileTitle(profiling, prevTitle, sizeof(prevTitle));
+  ProfileTitle(profiling->profilerSeq, prevTitle, sizeof(prevTitle));
   profiling->profilerSeq++;
   char nextTitle[64];
-  ProfileTitle(profiling, nextTitle, sizeof(nextTitle));
+  ProfileTitle(profiling->profilerSeq, nextTitle, sizeof(nextTitle));
 
   profiling->activationDepth = 0;
   int64_t newStartTime = HrTime();
@@ -929,11 +929,11 @@ NAN_METHOD(StopProfiling) {
     return;
   }
 
-  char title[64];
-  ProfileTitle(profiling, title, sizeof(title));
+  char prevTitle[64];
+  ProfileTitle(profiling->profilerSeq, prevTitle, sizeof(prevTitle));
 
   v8::CpuProfile* profile =
-    profiling->profiler->StopProfiling(Nan::New(title).ToLocalChecked());
+    profiling->profiler->StopProfiling(Nan::New(prevTitle).ToLocalChecked());
   if (!profile) {
     // profile with this title might've already be ended using a previous stop call
     return;

--- a/src/native_ext/profiling.cpp
+++ b/src/native_ext/profiling.cpp
@@ -846,12 +846,13 @@ void ProfilingReset(Profiling* profiling) {
 }
 
 NAN_METHOD(CollectProfilingData) {
-  auto jsProfilingData = Nan::New<v8::Object>();
-  info.GetReturnValue().Set(jsProfilingData);
-
   if (!profiling) {
+    info.GetReturnValue().SetNull();
     return;
   }
+
+  auto jsProfilingData = Nan::New<v8::Object>();
+  info.GetReturnValue().Set(jsProfilingData);
 
   char prevTitle[64];
   ProfileTitle(profiling, prevTitle, sizeof(prevTitle));
@@ -878,12 +879,13 @@ NAN_METHOD(CollectProfilingData) {
 }
 
 NAN_METHOD(CollectProfilingDataRaw) {
-  auto jsProfilingData = Nan::New<v8::Object>();
-  info.GetReturnValue().Set(jsProfilingData);
-
   if (!profiling) {
+    info.GetReturnValue().SetNull();
     return;
   }
+
+  auto jsProfilingData = Nan::New<v8::Object>();
+  info.GetReturnValue().Set(jsProfilingData);
 
   char prevTitle[64];
   ProfileTitle(profiling, prevTitle, sizeof(prevTitle));
@@ -910,12 +912,13 @@ NAN_METHOD(CollectProfilingDataRaw) {
 }
 
 NAN_METHOD(StopProfiling) {
-  auto jsProfilingData = Nan::New<v8::Object>();
-  info.GetReturnValue().Set(jsProfilingData);
-
   if (!profiling) {
+    info.GetReturnValue().SetNull();
     return;
   }
+
+  auto jsProfilingData = Nan::New<v8::Object>();
+  info.GetReturnValue().Set(jsProfilingData);
 
   char title[64];
   ProfileTitle(profiling, title, sizeof(title));

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -101,8 +101,10 @@ export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
   const interval = setInterval(() => {
     const profilingData = extCollectSamples(extension);
 
-    for (const exporter of exporters) {
-      exporter.send(profilingData);
+    if (profilingData) {
+      for (const exporter of exporters) {
+        exporter.send(profilingData);
+      }
     }
   }, options.collectionDuration);
 
@@ -113,8 +115,10 @@ export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
       clearInterval(interval);
       const profilingData = extStopProfiling(extension);
 
-      for (const exporter of exporters) {
-        exporter.send(profilingData);
+      if (profilingData) {
+        for (const exporter of exporters) {
+          exporter.send(profilingData);
+        }
       }
     },
   };

--- a/test/profiling/extension.test.ts
+++ b/test/profiling/extension.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
+import { strict as assert } from 'assert';
 import { hrtime } from 'process';
 import { ProfilingExtension } from '../../src/profiling/types';
 import * as utils from '../utils';
@@ -38,7 +38,14 @@ describe('profiling native extension', () => {
     extension.stop();
   });
 
+  it('calling stop without initialized profiling returns null', () => {
+    assert.equal(extension.stop(), null);
+  });
+
   it('is possible to collect stacktraces', () => {
+    // returns null if no profiling started
+    assert.equal(extension.collect(), null);
+
     // Use a lower interval to make sure we capture something
     extension.start({
       samplingIntervalMicroseconds: 1_000,
@@ -66,8 +73,8 @@ describe('profiling native extension', () => {
       // The first two lines are intentionally empty,
       // as we don't have information about the thread state.
       const lines = stacktrace.split('\n');
-      assert.deepStrictEqual(lines[0], '');
-      assert.deepStrictEqual(lines[1], '');
+      assert.deepEqual(lines[0], '');
+      assert.deepEqual(lines[1], '');
       const stacklines = lines.slice(2, -1);
 
       for (const stackline of stacklines) {
@@ -77,6 +84,9 @@ describe('profiling native extension', () => {
   });
 
   it('is possible to collect raw data on stacktraces', () => {
+    // returns null if no profiling started
+    assert.equal(extension.collectRaw(), null);
+
     // Use a lower interval to make sure we capture something
     extension.start({
       samplingIntervalMicroseconds: 1_000,
@@ -103,11 +113,11 @@ describe('profiling native extension', () => {
 
       for (const traceline of stacktrace) {
         assert(Array.isArray(traceline));
-        assert.strictEqual(traceline.length, 4);
-        assert.strictEqual(typeof traceline[0], 'string'); // filename
-        assert.strictEqual(typeof traceline[1], 'string'); // function name
-        assert.strictEqual(typeof traceline[2], 'number'); // line number
-        assert.strictEqual(typeof traceline[3], 'number'); // column number
+        assert.equal(traceline.length, 4);
+        assert.equal(typeof traceline[0], 'string'); // filename
+        assert.equal(typeof traceline[1], 'string'); // function name
+        assert.equal(typeof traceline[2], 'number'); // line number
+        assert.equal(typeof traceline[3], 'number'); // column number
       }
     }
   });

--- a/test/profiling/extension.test.ts
+++ b/test/profiling/extension.test.ts
@@ -17,13 +17,9 @@
 import * as assert from 'assert';
 import { hrtime } from 'process';
 import { ProfilingExtension } from '../../src/profiling/types';
+import * as utils from '../utils';
 
 const extension: ProfilingExtension = require('../../src/native_ext').profiling;
-
-function spinMs(ms: number) {
-  const start = Date.now();
-  while (Date.now() - start < ms) {}
-}
 
 function assertNanoSecondString(timestamp: any) {
   assert.equal(typeof timestamp, 'string');
@@ -49,7 +45,7 @@ describe('profiling native extension', () => {
       recordDebugInfo: false,
     });
 
-    spinMs(100);
+    utils.spinMs(100);
 
     const result = extension.collect();
     // The types might not be what is declared in typescript, a sanity check.
@@ -87,7 +83,7 @@ describe('profiling native extension', () => {
       recordDebugInfo: false,
     });
 
-    spinMs(100);
+    utils.spinMs(100);
 
     const result = extension.collectRaw();
     // The types might not be what is declared in typescript, a sanity check.

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -148,5 +148,27 @@ describe('profiling', () => {
       // Stop flushes the exporters, hence the extra call count
       assert.deepStrictEqual(sendCallCount, 2);
     });
+
+    it('does not call Exporter#send if profiling has not started', async () => {
+      let sendCallCount = 0;
+      const stacktracesReceived = [];
+      const exporter: ProfilingExporter = {
+        send(profilingData: ProfilingData) {
+          sendCallCount += 1;
+        },
+      };
+
+      // enabling tracing is required for span information to be caught
+      const { stop } = startProfiling({
+        serviceName: 'slow-service',
+        callstackInterval: 50,
+        collectionDuration: 500,
+        exporterFactory: () => [exporter],
+      });
+
+      stop();
+
+      assert.equal(sendCallCount, 0);
+    });
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -39,3 +39,8 @@ export const cleanEnvironment = () => {
       delete process.env[key];
     });
 };
+
+export const spinMs = (ms: number) => {
+  const start = Date.now();
+  while (Date.now() - start < ms) {}
+};


### PR DESCRIPTION
# Description

Adding tests for the tracing in JS side.

While doing that noticed, that double-stoping or stopping and then collecting resulted in a runtime crash. added a fix for that as well.

Another unexpected behavior was about starting the profiler. Currently done in `setImmediate` which means that syncronous tasks in the same eventloop round would not be caught by the profiler. Syncronous profiling will thus not work. **Are we OK with that?**
As the bare minimum, we should at least return a promise so it would be possible to await for the profiler to start before doing any work. OR opt in for syncronous start and make users wrap it on their own if they want to leave their startup times unaffected.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Internal change (a change which is not visible to the package consumers)
- [x] Documentation change or requires a documentation update

# How Has This Been Tested?

- [ ] Tested manually
- [x] Added automated tests

# Checklist:

- [x] Unit tests have been added/updated
- [ ] Documentation has been updated
- [ ] Change file has been generated (`npm run change:new`)
- [ ] Delete this branch (after the PR is merged)
