### PR TITLE
feat: start profiler syncronously

### DIFF
--- a/change/@splunk-otel-fe8fde88-7d17-48e4-9a86-0052e39bf3aa.json
+++ b/change/@splunk-otel-fe8fde88-7d17-48e4-9a86-0052e39bf3aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: start profiling syncronously",
+  "packageName": "@splunk/otel",
+  "email": "rauno56@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -97,9 +97,7 @@ export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
     recordDebugInfo: options.debugExport,
   };
 
-  setImmediate(() => {
-    extStartProfiling(extension, startOptions);
-  });
+  extStartProfiling(extension, startOptions);
 
   const interval = setInterval(() => {
     const profilingData = extCollectSamples(extension);

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -148,27 +148,5 @@ describe('profiling', () => {
       // Stop flushes the exporters, hence the extra call count
       assert.deepStrictEqual(sendCallCount, 2);
     });
-
-    it('does not call Exporter#send if profiling has not started', async () => {
-      let sendCallCount = 0;
-      const stacktracesReceived = [];
-      const exporter: ProfilingExporter = {
-        send(profilingData: ProfilingData) {
-          sendCallCount += 1;
-        },
-      };
-
-      // enabling tracing is required for span information to be caught
-      const { stop } = startProfiling({
-        serviceName: 'slow-service',
-        callstackInterval: 50,
-        collectionDuration: 500,
-        exporterFactory: () => [exporter],
-      });
-
-      stop();
-
-      assert.equal(sendCallCount, 0);
-    });
   });
 });


### PR DESCRIPTION
# Description

Made starting profiler sync and removed a test that relies on the async behavior.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Internal change (a change which is not visible to the package consumers)
- [ ] Documentation change or requires a documentation update

# How Has This Been Tested?

- [ ] Tested manually
- [ ] Added automated tests

# Checklist:

- [ ] Unit tests have been added/updated
- [ ] Documentation has been updated
- [x] Change file has been generated (`npm run change:new`)
- [ ] Delete this branch (after the PR is merged)
