### PR TITLE
fix: profiling: avoid biased samples due to self sampling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         include:
           - os: windows-2019
             label: windows
-          - os: macos-10.15
+          - os: macos-11
             label: macos
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -92,8 +92,10 @@ export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
 
   const exporters = options.exporterFactory(options);
 
+  const samplingIntervalMicroseconds = options.callstackInterval * 1_000;
   const startOptions = {
-    samplingIntervalMicroseconds: options.callstackInterval * 1_000,
+    samplingIntervalMicroseconds,
+    maxSampleCutoffDelayMicroseconds: samplingIntervalMicroseconds / 2,
     recordDebugInfo: options.debugExport,
   };
 


### PR DESCRIPTION
`sample` - a call stack sample taken by the profiler at given intervals

**Problem**
Due to the V8 profiler start/stop workaround, we launch a new profiling run before finishing the previous run. When the new run starts, a sample is taken right away (after indeterminate amount of microseconds), which always creates a sample when collecting profiling data and toggling the V8 profiler (i.e. every 30 seconds), this means 1 sample (using sample interval of 1s) out of 30 is always the profiler's collect step. This causes a nasty bias in the data, where it looks like our profiler's collect step is taking way more time than it actually does.

For example during a collection interval of 30 seconds, 1/30 of the samples is the collect step, 2/30 samples are application code and 27/30 is idle. When filtering out idle samples (which our UI does), it seems as if the profiler is taking 33% of application time.

**Solution**
Filter out the biased sample if:
* It does not exceed the maximum cutoff delay (which is just a heuristic at the moment, half of the sampling interval). This is needed so that if our processing actually spends a lot of CPU time, the sample is not filtered out.
* It falls into the time interval of the collect function.