### PR TITLE
feat: memory profiling

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,6 +6,7 @@
       "src/native_ext/util/hex.cpp",
       "src/native_ext/module.cpp",
       "src/native_ext/metrics.cpp",
+      "src/native_ext/memory_profiling.cpp",
       "src/native_ext/profiling.cpp",
       "src/native_ext/util/modp_numtoa.cpp",
       "src/native_ext/util/platform.cpp"

--- a/scripts/prebuild-os.js
+++ b/scripts/prebuild-os.js
@@ -3,7 +3,7 @@ const prebuildify = require('prebuildify');
 let targets = process.argv.slice(2);
 
 if (targets.length == 0) {
-  targets = ['8.5.0', '9.0.0', '10.0.0', '11.0.0', '12.0.0', '13.0.0', '14.0.0', '15.0.0', '16.0.0', '17.0.1', '18.0.0'];
+  targets = ['12.0.0', '13.0.0', '14.0.0', '15.0.0', '16.0.0', '17.0.1', '18.0.0'];
 }
 
 prebuildify({

--- a/src/native_ext/memory_profiling.cpp
+++ b/src/native_ext/memory_profiling.cpp
@@ -1,0 +1,176 @@
+#include "memory_profiling.h"
+#include <v8-profiler.h>
+#include <vector>
+#include "util/platform.h"
+
+namespace Splunk {
+namespace Profiling {
+
+namespace {
+enum MemoryProfilingStringIndex {
+  V8String_Name,
+  V8String_ScriptName,
+  V8String_LineNumber,
+  V8String_Allocations,
+  V8String_Parent,
+  V8String_MAX
+};
+
+struct BFSNode {
+  BFSNode(v8::AllocationProfile::Node* node, int32_t parentIndex)
+    : node(node), parentIndex(parentIndex) {}
+  v8::AllocationProfile::Node* node;
+  // Parent index in the flattened tree
+  int32_t parentIndex;
+};
+
+struct MemoryProfiling {
+  MemoryProfiling() {
+    stack.reserve(128);
+  }
+  std::vector<BFSNode> stack;
+  bool isRunning = false;
+};
+
+MemoryProfiling* profiling = nullptr;
+
+struct StringStash {
+  v8::Local<v8::String> strings[V8String_MAX];
+};
+
+v8::Local<v8::Object> ToJsHeapNode(v8::AllocationProfile::Node* node, int32_t parentIndex, StringStash* stash) {
+  auto jsNode = Nan::New<v8::Object>();
+  Nan::Set(jsNode, stash->strings[V8String_Name], node->name);
+  Nan::Set(jsNode, stash->strings[V8String_ScriptName], node->script_name);
+  Nan::Set(jsNode, stash->strings[V8String_LineNumber], Nan::New<v8::Integer>(node->line_number));
+  Nan::Set(jsNode, stash->strings[V8String_Parent], Nan::New<v8::Integer>(parentIndex));
+
+  auto jsAllocations = Nan::New<v8::Array>(node->allocations.size());
+  Nan::Set(jsNode, stash->strings[V8String_Allocations], jsAllocations);
+
+  for (size_t allocationIndex = 0; allocationIndex < node->allocations.size(); allocationIndex++) {
+    v8::AllocationProfile::Allocation* allocation = &node->allocations[allocationIndex];
+    Nan::Set(
+      jsAllocations, allocationIndex, Nan::New<v8::Number>(allocation->size * allocation->count));
+  }
+
+  return jsNode;
+}
+
+}
+
+NAN_METHOD(StartMemoryProfiling) {
+  if (!profiling) {
+    profiling = new MemoryProfiling();
+  }
+
+  if (profiling->isRunning) {
+    return;
+  }
+
+  v8::HeapProfiler* profiler = info.GetIsolate()->GetHeapProfiler();
+
+  if (!profiler) {
+    Nan::ThrowError("unable to get heap profiler - isolate not initialized"); 
+    return;
+  }
+
+  int64_t sampleIntervalBytes = 1024 * 256;
+  int32_t maxStackDepth = 256;
+
+  if (info.Length() >= 1 && info[0]->IsObject()) {
+    auto options = Nan::To<v8::Object>(info[0]).ToLocalChecked();
+    auto maybeSampleIntervalBytes =
+      Nan::Get(options, Nan::New("sampleIntervalBytes").ToLocalChecked());
+    if (!maybeSampleIntervalBytes.IsEmpty() && maybeSampleIntervalBytes.ToLocalChecked()->IsNumber()) {
+      sampleIntervalBytes = Nan::To<int64_t>(maybeSampleIntervalBytes.ToLocalChecked()).FromJust();
+    }
+
+    auto maybeMaxStackDepth =
+      Nan::Get(options, Nan::New("maxStackDepth").ToLocalChecked());
+    if (!maybeMaxStackDepth.IsEmpty() && maybeMaxStackDepth.ToLocalChecked()->IsNumber()) {
+      maxStackDepth = Nan::To<int32_t>(maybeMaxStackDepth.ToLocalChecked()).FromJust();
+    }
+  }
+
+  profiling->isRunning = profiler->StartSamplingHeapProfiler(sampleIntervalBytes, maxStackDepth);
+}
+
+NAN_METHOD(CollectHeapProfile) {
+  info.GetReturnValue().SetNull();
+
+  if (!profiling) {
+    return;
+  }
+
+  if (!profiling->isRunning) {
+    return;
+  }
+
+  v8::HeapProfiler* profiler = info.GetIsolate()->GetHeapProfiler();
+
+  if (!profiler) {
+    return;
+  }
+
+  v8::AllocationProfile* profile = profiler->GetAllocationProfile();
+
+  if (!profile) {
+    return;
+  }
+
+  auto jsResult = Nan::New<v8::Object>();
+  v8::AllocationProfile::Node* root = profile->GetRootNode();
+
+  uint32_t flatTreeLength = 0;
+  uint32_t leafsLength = 0;
+  auto flatTree = Nan::New<v8::Array>();
+  auto leafs = Nan::New<v8::Array>();
+
+  StringStash stash;
+  stash.strings[V8String_Name] = Nan::New<v8::String>("name").ToLocalChecked();
+  stash.strings[V8String_ScriptName] = Nan::New<v8::String>("scriptName").ToLocalChecked();
+  stash.strings[V8String_LineNumber] = Nan::New<v8::String>("lineNumber").ToLocalChecked();
+  stash.strings[V8String_Allocations] = Nan::New<v8::String>("allocations").ToLocalChecked();
+  stash.strings[V8String_Parent] = Nan::New<v8::String>("parent").ToLocalChecked();
+
+  std::vector<BFSNode>& stack = profiling->stack;
+  stack.clear();
+
+  // Cut off the root node
+  for (size_t i = 0; i < root->children.size(); i++) {
+    stack.emplace_back(root->children[i], -1);
+  }
+
+  while (!stack.empty()) {
+    BFSNode graphNode = stack.back();
+    stack.pop_back();
+
+    v8::AllocationProfile::Node* node = graphNode.node;
+
+    uint32_t indexOfNode = flatTreeLength++;
+    Nan::Set(flatTree, indexOfNode, ToJsHeapNode(node, graphNode.parentIndex, &stash));
+
+    if (node->children.size() == 0) {
+      Nan::Set(leafs, leafsLength++, Nan::New<v8::Number>(indexOfNode)); 
+    }
+    
+    for (size_t i = 0; i < node->children.size(); i++) {
+      stack.emplace_back(node->children[i], indexOfNode);
+    }
+  }
+
+  Nan::Set(jsResult, Nan::New<v8::String>("tree").ToLocalChecked(), flatTree);
+  Nan::Set(jsResult, Nan::New<v8::String>("leafs").ToLocalChecked(), leafs);
+
+  info.GetReturnValue().Set(jsResult);
+
+  delete profile;
+}
+
+NAN_METHOD(StopMemoryProfiling) {
+
+}
+
+} // namespace Profiling
+} // namespace Splunk

--- a/src/native_ext/memory_profiling.cpp
+++ b/src/native_ext/memory_profiling.cpp
@@ -12,7 +12,6 @@ enum MemoryProfilingStringIndex {
   V8String_Name,
   V8String_ScriptName,
   V8String_LineNumber,
-  V8String_Allocations,
   V8String_ParentId,
   V8String_MAX
 };
@@ -49,16 +48,6 @@ ToJsHeapNode(v8::AllocationProfile::Node* node, uint32_t parentId, StringStash* 
   Nan::Set(jsNode, stash->strings[V8String_ScriptName], node->script_name);
   Nan::Set(jsNode, stash->strings[V8String_LineNumber], Nan::New<v8::Integer>(node->line_number));
   Nan::Set(jsNode, stash->strings[V8String_ParentId], Nan::New<v8::Uint32>(parentId));
-
-  auto jsAllocations = Nan::New<v8::Array>(node->allocations.size());
-  Nan::Set(jsNode, stash->strings[V8String_Allocations], jsAllocations);
-
-  for (size_t allocationIndex = 0; allocationIndex < node->allocations.size(); allocationIndex++) {
-    v8::AllocationProfile::Allocation* allocation = &node->allocations[allocationIndex];
-    Nan::Set(
-      jsAllocations, allocationIndex, Nan::New<v8::Number>(allocation->size * allocation->count));
-  }
-
   return jsNode;
 }
 
@@ -172,7 +161,6 @@ NAN_METHOD(CollectHeapProfile) {
   stash.strings[V8String_Name] = Nan::New<v8::String>("name").ToLocalChecked();
   stash.strings[V8String_ScriptName] = Nan::New<v8::String>("scriptName").ToLocalChecked();
   stash.strings[V8String_LineNumber] = Nan::New<v8::String>("lineNumber").ToLocalChecked();
-  stash.strings[V8String_Allocations] = Nan::New<v8::String>("allocations").ToLocalChecked();
   stash.strings[V8String_ParentId] = Nan::New<v8::String>("parentId").ToLocalChecked();
 
   std::vector<BFSNode>& stack = profiling->stack;
@@ -199,6 +187,9 @@ NAN_METHOD(CollectHeapProfile) {
 
   Nan::Set(jsResult, Nan::New<v8::String>("treeMap").ToLocalChecked(), jsNodeTree);
   Nan::Set(jsResult, Nan::New<v8::String>("samples").ToLocalChecked(), jsSamples);
+  Nan::Set(
+    jsResult, Nan::New<v8::String>("timestamp").ToLocalChecked(),
+    Nan::New<v8::Number>(MilliSecondsSinceEpoch()));
 
   info.GetReturnValue().Set(jsResult);
 

--- a/src/native_ext/memory_profiling.cpp
+++ b/src/native_ext/memory_profiling.cpp
@@ -1,7 +1,8 @@
 #include "memory_profiling.h"
+#include "util/platform.h"
+#include <unordered_map>
 #include <v8-profiler.h>
 #include <vector>
-#include "util/platform.h"
 
 namespace Splunk {
 namespace Profiling {
@@ -12,23 +13,25 @@ enum MemoryProfilingStringIndex {
   V8String_ScriptName,
   V8String_LineNumber,
   V8String_Allocations,
-  V8String_Parent,
+  V8String_ParentId,
   V8String_MAX
 };
 
 struct BFSNode {
-  BFSNode(v8::AllocationProfile::Node* node, int32_t parentIndex)
-    : node(node), parentIndex(parentIndex) {}
+  BFSNode(v8::AllocationProfile::Node* node, uint32_t parentId)
+    : node(node), parentId(parentId) {}
   v8::AllocationProfile::Node* node;
-  // Parent index in the flattened tree
-  int32_t parentIndex;
+  uint32_t parentId;
 };
 
+using AllocationSample = v8::AllocationProfile::Sample;
+
 struct MemoryProfiling {
-  MemoryProfiling() {
-    stack.reserve(128);
-  }
+  MemoryProfiling() { stack.reserve(128); }
   std::vector<BFSNode> stack;
+  uint64_t generation = 0;
+  // Used to keep track which were the new samples added to the allocation profile.
+  std::unordered_map<uint64_t, uint64_t> sampleTracking;
   bool isRunning = false;
 };
 
@@ -38,12 +41,13 @@ struct StringStash {
   v8::Local<v8::String> strings[V8String_MAX];
 };
 
-v8::Local<v8::Object> ToJsHeapNode(v8::AllocationProfile::Node* node, int32_t parentIndex, StringStash* stash) {
+v8::Local<v8::Object> ToJsHeapNode(
+  v8::AllocationProfile::Node* node, uint32_t parentId, StringStash* stash) {
   auto jsNode = Nan::New<v8::Object>();
   Nan::Set(jsNode, stash->strings[V8String_Name], node->name);
   Nan::Set(jsNode, stash->strings[V8String_ScriptName], node->script_name);
   Nan::Set(jsNode, stash->strings[V8String_LineNumber], Nan::New<v8::Integer>(node->line_number));
-  Nan::Set(jsNode, stash->strings[V8String_Parent], Nan::New<v8::Integer>(parentIndex));
+  Nan::Set(jsNode, stash->strings[V8String_ParentId], Nan::New<v8::Uint32>(parentId));
 
   auto jsAllocations = Nan::New<v8::Array>(node->allocations.size());
   Nan::Set(jsNode, stash->strings[V8String_Allocations], jsAllocations);
@@ -57,7 +61,7 @@ v8::Local<v8::Object> ToJsHeapNode(v8::AllocationProfile::Node* node, int32_t pa
   return jsNode;
 }
 
-}
+} // namespace
 
 NAN_METHOD(StartMemoryProfiling) {
   if (!profiling) {
@@ -71,23 +75,24 @@ NAN_METHOD(StartMemoryProfiling) {
   v8::HeapProfiler* profiler = info.GetIsolate()->GetHeapProfiler();
 
   if (!profiler) {
-    Nan::ThrowError("unable to get heap profiler - isolate not initialized"); 
+    Nan::ThrowError("unable to get heap profiler - isolate not initialized");
     return;
   }
 
-  int64_t sampleIntervalBytes = 1024 * 256;
-  int32_t maxStackDepth = 256;
+  int64_t sampleIntervalBytes = 1024 * 128;
+  int32_t maxStackDepth = 128;
 
   if (info.Length() >= 1 && info[0]->IsObject()) {
     auto options = Nan::To<v8::Object>(info[0]).ToLocalChecked();
     auto maybeSampleIntervalBytes =
       Nan::Get(options, Nan::New("sampleIntervalBytes").ToLocalChecked());
-    if (!maybeSampleIntervalBytes.IsEmpty() && maybeSampleIntervalBytes.ToLocalChecked()->IsNumber()) {
+    if (
+      !maybeSampleIntervalBytes.IsEmpty() &&
+      maybeSampleIntervalBytes.ToLocalChecked()->IsNumber()) {
       sampleIntervalBytes = Nan::To<int64_t>(maybeSampleIntervalBytes.ToLocalChecked()).FromJust();
     }
 
-    auto maybeMaxStackDepth =
-      Nan::Get(options, Nan::New("maxStackDepth").ToLocalChecked());
+    auto maybeMaxStackDepth = Nan::Get(options, Nan::New("maxStackDepth").ToLocalChecked());
     if (!maybeMaxStackDepth.IsEmpty() && maybeMaxStackDepth.ToLocalChecked()->IsNumber()) {
       maxStackDepth = Nan::To<int32_t>(maybeMaxStackDepth.ToLocalChecked()).FromJust();
     }
@@ -120,26 +125,52 @@ NAN_METHOD(CollectHeapProfile) {
   }
 
   auto jsResult = Nan::New<v8::Object>();
+  auto jsSamples = Nan::New<v8::Array>();
+  auto jsNodeTree = Nan::New<v8::Object>();
+  int32_t jsSamplesLength = 0;
+
   v8::AllocationProfile::Node* root = profile->GetRootNode();
 
-  uint32_t flatTreeLength = 0;
-  uint32_t leafsLength = 0;
-  auto flatTree = Nan::New<v8::Array>();
-  auto leafs = Nan::New<v8::Array>();
+  const std::vector<v8::AllocationProfile::Sample>& samples = profile->GetSamples();
+
+  profiling->generation++;
+
+  std::unordered_map<uint64_t, uint64_t>& sampleTracking = profiling->sampleTracking;
+
+  for (const auto& sample : samples) {
+    if (sampleTracking.count(sample.sample_id) == 0) {
+      auto jsSample = Nan::New<v8::Object>();
+      Nan::Set(
+        jsSample, Nan::New<v8::String>("nodeId").ToLocalChecked(), Nan::New<v8::Uint32>(sample.node_id));
+      Nan::Set(
+        jsSample, Nan::New<v8::String>("size").ToLocalChecked(),
+        Nan::New<v8::Uint32>(uint32_t(sample.size * sample.count)));
+      Nan::Set(jsSamples, jsSamplesLength++, jsSample);
+    }
+    sampleTracking[sample.sample_id] = profiling->generation;
+  }
+
+  for (auto it = sampleTracking.begin(); it != sampleTracking.end();) {
+    if (it->second != profiling->generation) {
+      it = sampleTracking.erase(it);
+    } else {
+      ++it;
+    }
+  }
 
   StringStash stash;
   stash.strings[V8String_Name] = Nan::New<v8::String>("name").ToLocalChecked();
   stash.strings[V8String_ScriptName] = Nan::New<v8::String>("scriptName").ToLocalChecked();
   stash.strings[V8String_LineNumber] = Nan::New<v8::String>("lineNumber").ToLocalChecked();
   stash.strings[V8String_Allocations] = Nan::New<v8::String>("allocations").ToLocalChecked();
-  stash.strings[V8String_Parent] = Nan::New<v8::String>("parent").ToLocalChecked();
+  stash.strings[V8String_ParentId] = Nan::New<v8::String>("parentId").ToLocalChecked();
 
   std::vector<BFSNode>& stack = profiling->stack;
   stack.clear();
 
   // Cut off the root node
   for (size_t i = 0; i < root->children.size(); i++) {
-    stack.emplace_back(root->children[i], -1);
+    stack.emplace_back(root->children[i], root->node_id);
   }
 
   while (!stack.empty()) {
@@ -148,29 +179,23 @@ NAN_METHOD(CollectHeapProfile) {
 
     v8::AllocationProfile::Node* node = graphNode.node;
 
-    uint32_t indexOfNode = flatTreeLength++;
-    Nan::Set(flatTree, indexOfNode, ToJsHeapNode(node, graphNode.parentIndex, &stash));
+    auto jsNode = ToJsHeapNode(node, graphNode.parentId, &stash);
+    Nan::Set(jsNodeTree, Nan::New<v8::Uint32>(node->node_id), jsNode);
 
-    if (node->children.size() == 0) {
-      Nan::Set(leafs, leafsLength++, Nan::New<v8::Number>(indexOfNode)); 
-    }
-    
     for (size_t i = 0; i < node->children.size(); i++) {
-      stack.emplace_back(node->children[i], indexOfNode);
+      stack.emplace_back(node->children[i], node->node_id);
     }
   }
 
-  Nan::Set(jsResult, Nan::New<v8::String>("tree").ToLocalChecked(), flatTree);
-  Nan::Set(jsResult, Nan::New<v8::String>("leafs").ToLocalChecked(), leafs);
+  Nan::Set(jsResult, Nan::New<v8::String>("treeMap").ToLocalChecked(), jsNodeTree);
+  Nan::Set(jsResult, Nan::New<v8::String>("samples").ToLocalChecked(), jsSamples);
 
   info.GetReturnValue().Set(jsResult);
 
   delete profile;
 }
 
-NAN_METHOD(StopMemoryProfiling) {
-
-}
+NAN_METHOD(StopMemoryProfiling) {}
 
 } // namespace Profiling
 } // namespace Splunk

--- a/src/native_ext/memory_profiling.h
+++ b/src/native_ext/memory_profiling.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/src/native_ext/memory_profiling.h
+++ b/src/native_ext/memory_profiling.h
@@ -1,1 +1,13 @@
 #pragma once
+
+#include <nan.h>
+
+namespace Splunk {
+namespace Profiling {
+
+NAN_METHOD(StartMemoryProfiling);
+NAN_METHOD(CollectHeapProfile);
+NAN_METHOD(StopMemoryProfiling);
+
+} // namespace Profiling
+} // namespace Splunk

--- a/src/native_ext/profiling.cpp
+++ b/src/native_ext/profiling.cpp
@@ -5,7 +5,6 @@
 #include "util/hex.h"
 #include "util/modp_numtoa.h"
 #include "util/platform.h"
-#include <chrono>
 #include <inttypes.h>
 #include <nan.h>
 #include <v8-profiler.h>
@@ -312,12 +311,6 @@ void InsertActivation(Profiling* profiling, SpanActivation* activation) {
 }
 
 Profiling* profiling = nullptr;
-
-int64_t MicroSecondsSinceEpoch() {
-  return std::chrono::duration_cast<std::chrono::microseconds>(
-           std::chrono::system_clock::now().time_since_epoch())
-    .count();
-}
 
 void V8StartProfiling(v8::CpuProfiler* profiler, const char* title) {
   v8::Local<v8::String> v8Title = Nan::New(title).ToLocalChecked();

--- a/src/native_ext/util/platform.cpp
+++ b/src/native_ext/util/platform.cpp
@@ -1,4 +1,5 @@
 #include "platform.h"
+#include <chrono>
 #include <uv.h>
 
 #ifdef __APPLE__
@@ -6,6 +7,14 @@
 #endif
 
 namespace Splunk {
+
+namespace {
+template <typename Duration>
+int64_t SinceEpoch() {
+  return std::chrono::duration_cast<Duration>(std::chrono::system_clock::now().time_since_epoch())
+    .count();
+}
+} // namespace
 
 #ifdef __APPLE__
 int64_t HrTime() {
@@ -19,4 +28,9 @@ int64_t HrTime() {
 #else
 int64_t HrTime() { return uv_hrtime(); }
 #endif
+
+int64_t MicroSecondsSinceEpoch() { return SinceEpoch<std::chrono::microseconds>(); }
+
+int64_t MilliSecondsSinceEpoch() { return SinceEpoch<std::chrono::milliseconds>(); }
+
 } // namespace Splunk

--- a/src/native_ext/util/platform.h
+++ b/src/native_ext/util/platform.h
@@ -4,4 +4,6 @@
 
 namespace Splunk {
 int64_t HrTime();
+int64_t MicroSecondsSinceEpoch();
+int64_t MilliSecondsSinceEpoch();
 }

--- a/src/profiling/DebugExporter.ts
+++ b/src/profiling/DebugExporter.ts
@@ -15,7 +15,7 @@
  */
 import * as fs from 'fs';
 import { diag } from '@opentelemetry/api';
-import { RawProfilingData, ProfilingData, ProfilingExporter } from './types';
+import { HeapProfile, RawProfilingData, ProfilingData, ProfilingExporter } from './types';
 
 export class DebugExporter implements ProfilingExporter {
   runTimestamp = Date.now();
@@ -28,5 +28,8 @@ export class DebugExporter implements ProfilingExporter {
         diag.error(`error writing to ${baseName}`, err);
       }
     });
+  }
+
+  sendHeapProfile(profile: HeapProfile) {
   }
 }

--- a/src/profiling/DebugExporter.ts
+++ b/src/profiling/DebugExporter.ts
@@ -20,6 +20,7 @@ import { HeapProfile, RawProfilingData, ProfilingData, ProfilingExporter } from 
 export class DebugExporter implements ProfilingExporter {
   runTimestamp = Date.now();
   profileIndex = 0;
+  heapProfileIndex = 0;
 
   send(data: ProfilingData | RawProfilingData) {
     const baseName = `profile-${this.runTimestamp}-${this.profileIndex++}.json`;
@@ -31,5 +32,12 @@ export class DebugExporter implements ProfilingExporter {
   }
 
   sendHeapProfile(profile: HeapProfile) {
+    const name = `heap-profile-${this.runTimestamp}-${this.heapProfileIndex++}.json`;
+    fs.writeFile(name, JSON.stringify(profile), err => {
+      if (err) {
+        diag.error(`error writing to ${name}`, err);
+      }
+    });
   }
+
 }

--- a/src/profiling/DebugExporter.ts
+++ b/src/profiling/DebugExporter.ts
@@ -15,7 +15,12 @@
  */
 import * as fs from 'fs';
 import { diag } from '@opentelemetry/api';
-import { HeapProfile, RawProfilingData, ProfilingData, ProfilingExporter } from './types';
+import {
+  HeapProfile,
+  ProfilingData,
+  ProfilingExporter,
+  RawProfilingData,
+} from './types';
 
 export class DebugExporter implements ProfilingExporter {
   runTimestamp = Date.now();
@@ -32,12 +37,12 @@ export class DebugExporter implements ProfilingExporter {
   }
 
   sendHeapProfile(profile: HeapProfile) {
-    const name = `heap-profile-${this.runTimestamp}-${this.heapProfileIndex++}.json`;
+    const name = `heap-profile-${this.runTimestamp}-${this
+      .heapProfileIndex++}.json`;
     fs.writeFile(name, JSON.stringify(profile), err => {
       if (err) {
         diag.error(`error writing to ${name}`, err);
       }
     });
   }
-
 }

--- a/src/profiling/OTLPProfilingExporter.ts
+++ b/src/profiling/OTLPProfilingExporter.ts
@@ -20,7 +20,12 @@ import { HeapProfile, RawProfilingData, ProfilingExporter } from './types';
 import { diag } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import { parseEndpoint, serialize, serializeHeapProfile, encode } from './utils';
+import {
+  parseEndpoint,
+  serialize,
+  serializeHeapProfile,
+  encode,
+} from './utils';
 
 export interface OTLPExporterOptions {
   callstackInterval: number;

--- a/src/profiling/OTLPProfilingExporter.ts
+++ b/src/profiling/OTLPProfilingExporter.ts
@@ -156,6 +156,11 @@ export class OTLPProfilingExporter implements ProfilingExporter {
   }
 
   sendHeapProfile(profile: HeapProfile) {
+    const beginT = process.hrtime.bigint();
+    const serialized = serializeHeapProfile(profile);
+    const endT = process.hrtime.bigint();
+    const serializeDur = Number(endT - beginT) / 1e6;
+    console.log(`serialize ${serializeDur.toFixed(3)}`);
     const attributes = [
       {
         key: 'profiling.data.format',
@@ -170,7 +175,7 @@ export class OTLPProfilingExporter implements ProfilingExporter {
         value: { stringValue: 'otel.profiling' },
       },
     ];
-    encode(serializeHeapProfile(profile))
+    encode(serialized)
       .then(serializedProfile => {
         const logs = [serializedProfile].map(st => {
           return {

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -83,10 +83,6 @@ export function defaultExporterFactory(
   return exporters;
 }
 
-declare global {
-  var SFX: any;
-}
-
 export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
   assertNoExtraneousProperties(opts, allowedProfilingOptions);
 
@@ -99,7 +95,6 @@ export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
       stop: () => {},
     };
   }
-
 
   const contextManager = new ProfilingContextManager();
   contextManager.enable();
@@ -133,10 +128,11 @@ export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
     const collectTime = process.hrtime.bigint();
     const collectDur = Number(collectTime - beginTime) / 1e6;
     console.log(`collect ${collectDur.toFixed(3)}`);
+    //console.dir(heapProfile, { depth: null, color: true });
     for (const exporter of exporters) {
       exporter.sendHeapProfile(heapProfile);
     }
-  }, 15_000);
+  }, 5_000);
 
   cpuSamplesCollectInterval.unref();
   memSamplesCollectInterval.unref();
@@ -200,7 +196,8 @@ export function _setDefaultOptions(
     })
   );
 
-  const memoryProfilingEnabled = options.memoryProfilingEnabled ??
+  const memoryProfilingEnabled =
+    options.memoryProfilingEnabled ??
     getEnvBoolean('SPLUNK_PROFILER_MEMORY_ENABLED') ??
     false;
 

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -64,7 +64,9 @@ function extStartMemoryProfiling(
   return extension.startMemoryProfiling(options);
 }
 
-function extCollectHeapProfile(extension: ProfilingExtension): HeapProfile {
+function extCollectHeapProfile(
+  extension: ProfilingExtension
+): HeapProfile | null {
   return extension.collectHeapProfile();
 }
 
@@ -136,8 +138,10 @@ export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
     extStartMemoryProfiling(extension, options.memoryProfilingOptions);
     memSamplesCollectInterval = setInterval(() => {
       const heapProfile = extCollectHeapProfile(extension);
-      for (const exporter of exporters) {
-        exporter.sendHeapProfile(heapProfile);
+      if (heapProfile) {
+        for (const exporter of exporters) {
+          exporter.sendHeapProfile(heapProfile);
+        }
       }
     }, options.collectionDuration);
 

--- a/src/profiling/proto/profile.js
+++ b/src/profiling/proto/profile.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 /*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
 "use strict";
 

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -75,7 +75,8 @@ export interface ProfilingExtension {
   collectRaw(): RawProfilingData;
   enterContext(context: unknown, traceId: string, spanId: string): void;
   exitContext(context: unknown): void;
-  startMemoryProfiling(): void;
+  startMemoryProfiling(options?: MemoryProfilingOptions): void;
+  stopMemoryProfiling(): void;
   collectHeapProfile(): HeapProfile;
 }
 

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -55,11 +55,17 @@ export interface HeapProfileNode {
   lineNumber: number;
   allocations: number[];
   parent: number;
+  parentId: number;
+}
+
+export interface AllocationSample {
+  nodeId: number;
+  size: number;
 }
 
 export interface HeapProfile {
-  tree: HeapProfileNode[];
-  leafs: number[];
+  samples: AllocationSample[];
+  treeMap: { [nodeId: string]: HeapProfileNode };
 }
 
 export interface ProfilingExtension {

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -49,6 +49,24 @@ export interface RawProfilingStackFrame extends Array<string | number> {
 export type RawProfilingData = GenericProfilingData<RawProfilingStackFrame[]>;
 export type ProfilingData = GenericProfilingData<string>;
 
+export interface Allocation {
+  size: number;
+  count: number;
+}
+
+export interface AllocationProfileNode {
+  name: string;
+  scriptName: string;
+  lineNumber: number;
+  id: number;
+  allocations: Allocation[];
+  children: AllocationProfileNode[];
+}
+
+export interface HeapProfile {
+  rootNode: AllocationProfileNode;
+}
+
 export interface ProfilingExtension {
   start(options?: ProfilingStartOptions): void;
   stop(): RawProfilingData;
@@ -56,6 +74,8 @@ export interface ProfilingExtension {
   collectRaw(): RawProfilingData;
   enterContext(context: unknown, traceId: string, spanId: string): void;
   exitContext(context: unknown): void;
+  startMemoryProfiling(): void;
+  collectMemorySamples(): HeapProfile; 
 }
 
 export type ProfilingExporterFactory = (
@@ -75,6 +95,7 @@ export interface ProfilingOptions {
 
 export interface ProfilingExporter {
   send(profile: RawProfilingData): void;
+  sendHeapProfile(profile: HeapProfile): void;
 }
 
 export const allowedProfilingOptions = [

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -49,22 +49,16 @@ export interface RawProfilingStackFrame extends Array<string | number> {
 export type RawProfilingData = GenericProfilingData<RawProfilingStackFrame[]>;
 export type ProfilingData = GenericProfilingData<string>;
 
-export interface Allocation {
-  size: number;
-  count: number;
-}
-
 export interface AllocationProfileNode {
   name: string;
   scriptName: string;
   lineNumber: number;
-  id: number;
-  allocations: Allocation[];
+  allocations: number[];
   children: AllocationProfileNode[];
 }
 
 export interface HeapProfile {
-  rootNode: AllocationProfileNode;
+  topDownNodes: [AllocationProfileNode];
 }
 
 export interface ProfilingExtension {

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -49,16 +49,17 @@ export interface RawProfilingStackFrame extends Array<string | number> {
 export type RawProfilingData = GenericProfilingData<RawProfilingStackFrame[]>;
 export type ProfilingData = GenericProfilingData<string>;
 
-export interface AllocationProfileNode {
+export interface HeapProfileNode {
   name: string;
   scriptName: string;
   lineNumber: number;
   allocations: number[];
-  children: AllocationProfileNode[];
+  parent: number;
 }
 
 export interface HeapProfile {
-  topDownNodes: [AllocationProfileNode];
+  tree: HeapProfileNode[];
+  leafs: number[];
 }
 
 export interface ProfilingExtension {
@@ -69,12 +70,17 @@ export interface ProfilingExtension {
   enterContext(context: unknown, traceId: string, spanId: string): void;
   exitContext(context: unknown): void;
   startMemoryProfiling(): void;
-  collectMemorySamples(): HeapProfile; 
+  collectHeapProfile(): HeapProfile;
 }
 
 export type ProfilingExporterFactory = (
   options: ProfilingOptions
 ) => ProfilingExporter[];
+
+export interface MemoryProfilingOptions {
+  maxStackDepth?: number;
+  sampleIntervalBytes?: number;
+}
 
 export interface ProfilingOptions {
   endpoint: string;
@@ -85,6 +91,8 @@ export interface ProfilingOptions {
   debugExport: boolean;
   resource: Resource;
   exporterFactory: ProfilingExporterFactory;
+  memoryProfilingEnabled: boolean;
+  memoryProfilingOptions?: MemoryProfilingOptions;
 }
 
 export interface ProfilingExporter {
@@ -100,4 +108,6 @@ export const allowedProfilingOptions = [
   'resource',
   'serviceName',
   'exporterFactory',
+  'memoryProfilingEnabled',
+  'memoryProfilingOptions',
 ];

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -76,7 +76,7 @@ export interface ProfilingExtension {
   exitContext(context: unknown): void;
   startMemoryProfiling(options?: MemoryProfilingOptions): void;
   stopMemoryProfiling(): void;
-  collectHeapProfile(): HeapProfile;
+  collectHeapProfile(): HeapProfile | null;
 }
 
 export type ProfilingExporterFactory = (

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -53,8 +53,6 @@ export interface HeapProfileNode {
   name: string;
   scriptName: string;
   lineNumber: number;
-  allocations: number[];
-  parent: number;
   parentId: number;
 }
 
@@ -66,6 +64,7 @@ export interface AllocationSample {
 export interface HeapProfile {
   samples: AllocationSample[];
   treeMap: { [nodeId: string]: HeapProfileNode };
+  timestamp: number;
 }
 
 export interface ProfilingExtension {

--- a/src/profiling/utils.ts
+++ b/src/profiling/utils.ts
@@ -148,16 +148,11 @@ class Serializer {
   ) {
     const { stacktraces } = profile;
 
-    const stringTable = new StringTable();
-    const locationsMap = new Map();
-    const functionsMap = new Map();
-
-    // Precreating those because they are really likely to be used
     const STR = {
-      TIMESTAMP: stringTable.getIndex('source.event.time'),
-      TRACE_ID: stringTable.getIndex('trace_id'),
-      SPAN_ID: stringTable.getIndex('span_id'),
-      SOURCE_EVENT_PERIOD: stringTable.getIndex('source.event.period'),
+      TIMESTAMP: this.stringTable.getIndex('source.event.time'),
+      TRACE_ID: this.stringTable.getIndex('trace_id'),
+      SPAN_ID: this.stringTable.getIndex('span_id'),
+      SOURCE_EVENT_PERIOD: this.stringTable.getIndex('source.event.period'),
     };
 
     const eventPeriodLabel = new perftools.profiles.Label({
@@ -178,7 +173,7 @@ class Serializer {
           labels.push(
             new perftools.profiles.Label({
               key: STR.TRACE_ID,
-              str: stringTable.getIndex(traceId.toString('hex')),
+              str: this.stringTable.getIndex(traceId.toString('hex')),
             })
           );
         }
@@ -186,7 +181,7 @@ class Serializer {
           labels.push(
             new perftools.profiles.Label({
               key: STR.SPAN_ID,
-              str: stringTable.getIndex(spanId.toString('hex')),
+              str: this.stringTable.getIndex(spanId.toString('hex')),
             })
           );
         }
@@ -203,9 +198,9 @@ class Serializer {
 
     return perftools.profiles.Profile.create({
       sample: samples,
-      location: [...locationsMap.values()],
-      function: [...functionsMap.values()],
-      stringTable: stringTable.serialize(),
+      location: [...this.locationsMap.values()],
+      function: [...this.functionsMap.values()],
+      stringTable: this.stringTable.serialize(),
     });
   }
 }

--- a/src/profiling/utils.ts
+++ b/src/profiling/utils.ts
@@ -50,206 +50,175 @@ export interface PProfSerializationOptions {
   samplingPeriodMillis: number;
 }
 
+class Serializer {
+  stringTable = new StringTable();
+  locationsMap = new Map();
+  functionsMap = new Map();
+
+  getLocation(
+    fileName: string,
+    functionName: string,
+    lineNumber: number
+  ): perftools.profiles.Location {
+    const key = `${fileName}:${functionName}:${lineNumber}`;
+    let location = this.locationsMap.get(key);
+    if (!location) {
+      location = new perftools.profiles.Location({
+        id: this.locationsMap.size + 1,
+        line: [this.getLine(fileName, functionName, lineNumber)],
+      });
+      this.locationsMap.set(key, location);
+    }
+    return location;
+  }
+
+  getFunction(
+    fileName: string,
+    functionName: string
+  ): perftools.profiles.Function {
+    const key = `${fileName}:${functionName}`;
+    let fun = this.functionsMap.get(key);
+    if (!fun) {
+      const functionNameId = this.stringTable.getIndex(functionName);
+      fun = new perftools.profiles.Function({
+        id: this.functionsMap.size + 1,
+        name: functionNameId,
+        systemName: functionNameId,
+        filename: this.stringTable.getIndex(fileName),
+      });
+      this.functionsMap.set(key, fun);
+    }
+    return fun;
+  }
+
+  getLine(
+    fileName: string,
+    functionName: string,
+    lineNumber: number
+  ): perftools.profiles.Line {
+    return new perftools.profiles.Line({
+      functionId: this.getFunction(fileName, functionName).id,
+      line: lineNumber !== 0 ? lineNumber : -1,
+    });
+  }
+
+  serializeHeapProfile(profile: HeapProfile) {
+    const SOURCE_EVENT_TIME = this.stringTable.getIndex('source.event.time');
+
+    const label = [{ key: SOURCE_EVENT_TIME, num: Date.now() }];
+
+    const sample: perftools.profiles.ISample[] = [];
+
+    const { samples, treeMap } = profile;
+
+    for (const s of samples) {
+      let node = treeMap[s.nodeId];
+      const path: number[] = [];
+
+      while (node !== undefined) {
+        const location = this.getLocation(
+          node.scriptName,
+          node.name,
+          node.lineNumber
+        );
+
+        path.push(location.id as number);
+
+        node = treeMap[node.parentId];
+      }
+
+      sample.push({
+        locationId: path,
+        value: [s.size],
+        label,
+      });
+    }
+
+    return perftools.profiles.Profile.create({
+      sample,
+      location: [...this.locationsMap.values()],
+      function: [...this.functionsMap.values()],
+      stringTable: this.stringTable.serialize(),
+    });
+  }
+
+  serializeCpuProfile(
+    profile: RawProfilingData,
+    options: PProfSerializationOptions
+  ) {
+    const { stacktraces } = profile;
+
+    const stringTable = new StringTable();
+    const locationsMap = new Map();
+    const functionsMap = new Map();
+
+    // Precreating those because they are really likely to be used
+    const STR = {
+      TIMESTAMP: stringTable.getIndex('source.event.time'),
+      TRACE_ID: stringTable.getIndex('trace_id'),
+      SPAN_ID: stringTable.getIndex('span_id'),
+      SOURCE_EVENT_PERIOD: stringTable.getIndex('source.event.period'),
+    };
+
+    const eventPeriodLabel = new perftools.profiles.Label({
+      key: STR.SOURCE_EVENT_PERIOD,
+      num: options.samplingPeriodMillis,
+    });
+
+    const samples = stacktraces.map(
+      ({ stacktrace, timestamp, spanId, traceId }) => {
+        const labels = [
+          new perftools.profiles.Label({
+            key: STR.TIMESTAMP,
+            num: Number(BigInt(timestamp) / BigInt(1_000_000)),
+          }),
+          eventPeriodLabel,
+        ];
+        if (traceId) {
+          labels.push(
+            new perftools.profiles.Label({
+              key: STR.TRACE_ID,
+              str: stringTable.getIndex(traceId.toString('hex')),
+            })
+          );
+        }
+        if (spanId) {
+          labels.push(
+            new perftools.profiles.Label({
+              key: STR.SPAN_ID,
+              str: stringTable.getIndex(spanId.toString('hex')),
+            })
+          );
+        }
+
+        return new perftools.profiles.Sample({
+          locationId: stacktrace.map(([fileName, functionName, lineNumber]) => {
+            return this.getLocation(fileName, functionName, lineNumber).id;
+          }),
+          value: [],
+          label: labels,
+        });
+      }
+    );
+
+    return perftools.profiles.Profile.create({
+      sample: samples,
+      location: [...locationsMap.values()],
+      function: [...functionsMap.values()],
+      stringTable: stringTable.serialize(),
+    });
+  }
+}
+
 export const serialize = (
   profile: RawProfilingData,
   options: PProfSerializationOptions
 ) => {
-  const { stacktraces } = profile;
-
-  const stringTable = new StringTable();
-  const locationsMap = new Map();
-  const functionsMap = new Map();
-
-  // Precreating those because they are really likely to be used
-  const STR = {
-    TIMESTAMP: stringTable.getIndex('source.event.time'),
-    TRACE_ID: stringTable.getIndex('trace_id'),
-    SPAN_ID: stringTable.getIndex('span_id'),
-    SOURCE_EVENT_PERIOD: stringTable.getIndex('source.event.period'),
-  };
-
-  const getLocation = (
-    fileName: string,
-    functionName: string,
-    lineNumber: number
-  ): perftools.profiles.Location => {
-    const key = [fileName, functionName, lineNumber].join(':');
-    let location = locationsMap.get(key);
-    if (!location) {
-      location = new perftools.profiles.Location({
-        id: locationsMap.size + 1,
-        line: [getLine(fileName, functionName, lineNumber)],
-      });
-      locationsMap.set(key, location);
-    }
-    return location;
-  };
-
-  const getFunction = (
-    fileName: string,
-    functionName: string
-  ): perftools.profiles.Function => {
-    const key = [fileName, functionName].join(':');
-    let fun = functionsMap.get(key);
-    if (!fun) {
-      const functionNameId = stringTable.getIndex(functionName);
-      fun = new perftools.profiles.Function({
-        id: functionsMap.size + 1,
-        name: functionNameId,
-        systemName: functionNameId,
-        filename: stringTable.getIndex(fileName || ''),
-      });
-      functionsMap.set(key, fun);
-    }
-    return fun;
-  };
-
-  const getLine = (
-    fileName: string,
-    functionName: string,
-    lineNumber: number
-  ): perftools.profiles.Line => {
-    return new perftools.profiles.Line({
-      functionId: getFunction(fileName, functionName).id,
-      line: lineNumber !== 0 ? lineNumber : -1,
-    });
-  };
-
-  const eventPeriodLabel = new perftools.profiles.Label({
-    key: STR.SOURCE_EVENT_PERIOD,
-    num: options.samplingPeriodMillis,
-  });
-  const samples = stacktraces.map(
-    ({ stacktrace, timestamp, spanId, traceId }) => {
-      const labels = [
-        new perftools.profiles.Label({
-          key: STR.TIMESTAMP,
-          num: Number(BigInt(timestamp) / BigInt(1_000_000)),
-        }),
-        eventPeriodLabel,
-      ];
-      if (traceId) {
-        labels.push(
-          new perftools.profiles.Label({
-            key: STR.TRACE_ID,
-            str: stringTable.getIndex(traceId.toString('hex')),
-          })
-        );
-      }
-      if (spanId) {
-        labels.push(
-          new perftools.profiles.Label({
-            key: STR.SPAN_ID,
-            str: stringTable.getIndex(spanId.toString('hex')),
-          })
-        );
-      }
-
-      return new perftools.profiles.Sample({
-        locationId: stacktrace.map(([fileName, functionName, lineNumber]) => {
-          return getLocation(fileName, functionName, lineNumber).id;
-        }),
-        value: [],
-        label: labels,
-      });
-    }
-  );
-
-  return perftools.profiles.Profile.create({
-    sample: samples,
-    location: [...locationsMap.values()],
-    function: [...functionsMap.values()],
-    stringTable: stringTable.serialize(),
-  });
+  return new Serializer().serializeCpuProfile(profile, options);
 };
 
 export function serializeHeapProfile(profile: HeapProfile) {
-  const stringTable = new StringTable();
-  const locationsMap = new Map();
-  const functionsMap = new Map();
-
-  // Precreating those because they are really likely to be used
-  const STR = {
-    SOURCE_EVENT_TIME: stringTable.getIndex('source.event.time'),
-  };
-
-  const getLocation = (
-    fileName: string,
-    functionName: string,
-    lineNumber: number
-  ): perftools.profiles.Location => {
-    const key = `${fileName}:${functionName}:${lineNumber}`;
-    let location = locationsMap.get(key);
-    if (!location) {
-      location = new perftools.profiles.Location({
-        id: locationsMap.size + 1,
-        line: [getLine(fileName, functionName, lineNumber)],
-      });
-      locationsMap.set(key, location);
-    }
-    return location;
-  };
-
-  const getFunction = (
-    fileName: string,
-    functionName: string
-  ): perftools.profiles.Function => {
-    const key = `${fileName}:${functionName}`;
-    let fun = functionsMap.get(key);
-    if (!fun) {
-      const functionNameId = stringTable.getIndex(functionName);
-      fun = new perftools.profiles.Function({
-        id: functionsMap.size + 1,
-        name: functionNameId,
-        systemName: functionNameId,
-        filename: stringTable.getIndex(fileName),
-      });
-      functionsMap.set(key, fun);
-    }
-    return fun;
-  };
-
-  const getLine = (
-    fileName: string,
-    functionName: string,
-    lineNumber: number
-  ): perftools.profiles.Line => {
-    return new perftools.profiles.Line({
-      functionId: getFunction(fileName, functionName).id,
-      line: lineNumber !== 0 ? lineNumber : -1,
-    });
-  };
-
-  const label = [{ key: STR.SOURCE_EVENT_TIME, num: Date.now() }];
-
-  const sample: perftools.profiles.ISample[] = [];
-
-  const { samples, treeMap } = profile;
-
-  for (const s of samples) {
-    let node = treeMap[s.nodeId];
-    const path: number[] = [];
-
-    while (node !== undefined) {
-      const location = getLocation(node.scriptName, node.name, node.lineNumber);
-      path.push(location.id as number);
-
-      node = treeMap[node.parentId];
-    }
-
-    sample.push({
-      locationId: path,
-      value: [s.size],
-      label,
-    });
-  }
-
-  return perftools.profiles.Profile.create({
-    sample,
-    location: [...locationsMap.values()],
-    function: [...functionsMap.values()],
-    stringTable: stringTable.serialize(),
-  });
+  return new Serializer().serializeHeapProfile(profile);
 }
 
 export const encode = async function encode(

--- a/src/profiling/utils.ts
+++ b/src/profiling/utils.ts
@@ -105,7 +105,7 @@ class Serializer {
   serializeHeapProfile(profile: HeapProfile) {
     const SOURCE_EVENT_TIME = this.stringTable.getIndex('source.event.time');
 
-    const label = [{ key: SOURCE_EVENT_TIME, num: Date.now() }];
+    const label = [{ key: SOURCE_EVENT_TIME, num: profile.timestamp }];
 
     const sample: perftools.profiles.ISample[] = [];
 

--- a/test/profiling/extension.test.ts
+++ b/test/profiling/extension.test.ts
@@ -16,7 +16,11 @@
 
 import { strict as assert } from 'assert';
 import { hrtime } from 'process';
-import { ProfilingExtension } from '../../src/profiling/types';
+import {
+  AllocationSample,
+  HeapProfileNode,
+  ProfilingExtension,
+} from '../../src/profiling/types';
 import * as utils from '../utils';
 
 const extension: ProfilingExtension = require('../../src/native_ext').profiling;
@@ -120,5 +124,79 @@ describe('profiling native extension', () => {
         assert.equal(typeof traceline[3], 'number'); // column number
       }
     }
+  });
+
+  it('is possible to collect a heap profile', () => {
+    assert.equal(extension.collectHeapProfile(), null);
+
+    extension.startMemoryProfiling();
+
+    function doAllocations() {
+      const dump = [];
+
+      for (let i = 0; i < 1024; i++) {
+        dump.push(`abcd-${i}`.repeat(2048));
+      }
+
+      return dump;
+    }
+
+    doAllocations();
+
+    const profile = extension.collectHeapProfile();
+
+    assert.notEqual(profile, null);
+    assert.equal(typeof profile.timestamp, 'number');
+    assert(
+      Date.now() - profile.timestamp <= 60_000,
+      'not a feasible heap profile timestamp'
+    );
+
+    const { treeMap, samples } = profile;
+
+    assert(samples.length > 0, 'no allocation samples');
+
+    let maybeLeaf: HeapProfileNode | undefined;
+    let leafNodeId;
+    for (const nodeId in treeMap) {
+      const node = treeMap[nodeId];
+      if (node.name === 'repeat') {
+        maybeLeaf = node;
+        leafNodeId = Number(nodeId);
+        break;
+      }
+    }
+
+    assert.notEqual(maybeLeaf, undefined);
+    assert.notEqual(leafNodeId, undefined);
+    const leaf = maybeLeaf!;
+    assert.deepEqual(leaf.lineNumber, 0);
+    assert.deepEqual(leaf.scriptName, '');
+    assert.deepEqual(typeof leaf.parentId, 'number');
+
+    const parentNode = treeMap[leaf.parentId];
+    assert(parentNode.lineNumber > 0, 'parent line number can not be empty');
+    assert(
+      parentNode.scriptName.endsWith('extension.test.ts'),
+      'invalid parent node file name'
+    );
+    assert.deepEqual(parentNode.name, 'doAllocations');
+    assert.deepEqual(typeof parentNode.parentId, 'number');
+
+    // No point going up the tree any more
+
+    let maybeSample: AllocationSample | undefined;
+
+    for (const s of samples) {
+      if (s.nodeId === leafNodeId) {
+        maybeSample = s;
+        break;
+      }
+    }
+
+    assert.notEqual(maybeSample, undefined);
+    const sample = maybeSample!;
+    assert.deepEqual(typeof sample.size, 'number');
+    assert(sample.size > 0, 'sample with zero size');
   });
 });

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -28,7 +28,11 @@ import {
   _setDefaultOptions,
 } from '../../src/profiling';
 import { start, stop } from '../../src';
-import { ProfilingExporter, ProfilingData } from '../../src/profiling/types';
+import {
+  HeapProfile,
+  ProfilingExporter,
+  RawProfilingData,
+} from '../../src/profiling/types';
 import { ProfilingContextManager } from '../../src/profiling/ProfilingContextManager';
 import { detect as detectResource } from '../../src/resource';
 
@@ -93,11 +97,12 @@ describe('profiling', () => {
       let sendCallCount = 0;
       const stacktracesReceived = [];
       const exporter: ProfilingExporter = {
-        send(profilingData: ProfilingData) {
+        send(profilingData: RawProfilingData) {
           const { stacktraces } = profilingData;
           sendCallCount += 1;
           stacktracesReceived.push(...stacktraces);
         },
+        sendHeapProfile(_profile: HeapProfile) {},
       };
 
       // enabling tracing is required for span information to be caught
@@ -149,6 +154,32 @@ describe('profiling', () => {
 
       // Stop flushes the exporters, hence the extra call count
       assert.deepStrictEqual(sendCallCount, 2);
+    });
+
+    it('exports heap profiles', async () => {
+      let sendCallCount = 0;
+      const exporter: ProfilingExporter = {
+        send(_profilingData: RawProfilingData) {},
+        sendHeapProfile(profile: HeapProfile) {
+          sendCallCount += 1;
+        },
+      };
+
+      // enabling tracing is required for span information to be caught
+      start({
+        profiling: {
+          serviceName: 'my-service',
+          collectionDuration: 100,
+          exporterFactory: () => [exporter],
+          memoryProfilingEnabled: true,
+        },
+      });
+
+      // let runtime empty the task-queue and enable profiling
+      await sleep(200);
+
+      stop();
+      assert(sendCallCount > 0, 'no profiles were sent');
     });
   });
 });

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -56,6 +56,8 @@ describe('profiling', () => {
           [SemanticResourceAttributes.SERVICE_NAME]: 'unnamed-node-service',
         }).merge(detectResource()),
         exporterFactory: defaultExporterFactory,
+        memoryProfilingEnabled: false,
+        memoryProfilingOptions: undefined,
       });
     });
 


### PR DESCRIPTION
:warning:  Targeting `pprof-export` branch, will need to be changed after `pprof-export` is merged.

### tldr

* Use `v8::HeapProfiler` to periodically capture an allocation profile along with the samples.
* The allocation samples returned from v8 are "live memory", so we have to keep track which samples were added.
* Samples have a `node_id` which is its node ID in the call graph. To generate a stack trace this node needs to be found from the allocation profile.
* For the finding the whole allocation profile graph is converted to a more convenient format, so when we have a node id, we can do a dictionary lookup and reconstruct the path to a root callgraph node which maps nicely to the pprof location array. The conversion requires generating the whole graph. There is room for improvement here (e.g. caching the node graph and only regenerate it when we find an unknown node_id from the samples), but at the moment it seems to be fast enough.

### Misc

* Removed obsolete Node.js versions (<12) from `prebuild:os` script