### PR TITLE
style: require parentheses around arrow function arguments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,8 +30,11 @@ module.exports = {
     ],
     "@typescript-eslint/no-unused-vars": ["error", {"argsIgnorePattern": "^_", "args": "after-used"}],
     "@typescript-eslint/no-inferrable-types": ["error", { ignoreProperties: true }],
-    "arrow-parens": ["error", "as-needed"],
-    "prettier/prettier": "error",
+    "arrow-parens": ["error", "always"],
+    "prettier/prettier": ["error", {
+      "singleQuote": true,
+      "arrowParens": "always"
+    }],
     "node/no-deprecated-api": ["warn"],
     "header/header": [2, "block", [
         "",

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,4 @@
 {
-  "singleQuote": true,
-  "arrowParens": "avoid"
+  "arrowParens": "always",
+  "singleQuote": true
 }

--- a/src/instrumentations/http.ts
+++ b/src/instrumentations/http.ts
@@ -55,7 +55,7 @@ function parseUrlParams(request: IncomingMessage) {
 }
 
 function captureUriParamByKeys(keys: string[]): IncomingHttpRequestHook {
-  const capturedKeys = new Map(keys.map(k => [k, k.replace(/\./g, '_')]));
+  const capturedKeys = new Map(keys.map((k) => [k, k.replace(/\./g, '_')]));
 
   return (span, request) => {
     const params = parseUrlParams(request);

--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { InstrumentationOption } from '@opentelemetry/instrumentation';
-
 import { load } from './loader';
 
 // please keep the list sorted alphabetically
@@ -66,7 +64,7 @@ const supportedInstrumentations: [string, string][] = [
   ['opentelemetry-instrumentation-typeorm', 'TypeormInstrumentation'],
 ];
 
-export function getInstrumentations(): InstrumentationOption[] {
+export function getInstrumentations() {
   const result = [];
 
   // Defensively load all supported instrumentations

--- a/src/instrumentations/redis.ts
+++ b/src/instrumentations/redis.ts
@@ -35,7 +35,7 @@ export function configureRedisInstrumentation(
       dbStatementSerializer: (cmd, args) => {
         if (args.length === 0) return cmd;
 
-        const sanitizedArgs = args.map(arg => {
+        const sanitizedArgs = args.map((arg) => {
           if (Buffer.isBuffer(arg)) {
             return `buffer(${arg.length})`;
           }

--- a/src/profiling/DebugExporter.ts
+++ b/src/profiling/DebugExporter.ts
@@ -23,7 +23,7 @@ export class DebugExporter implements ProfilingExporter {
 
   send(data: ProfilingData | RawProfilingData) {
     const baseName = `profile-${this.runTimestamp}-${this.profileIndex++}.json`;
-    fs.writeFile(baseName, JSON.stringify(data), err => {
+    fs.writeFile(baseName, JSON.stringify(data), (err) => {
       if (err) {
         diag.error(`error writing to ${baseName}`, err);
       }

--- a/src/profiling/OTLPProfilingExporter.ts
+++ b/src/profiling/OTLPProfilingExporter.ts
@@ -118,8 +118,8 @@ export class OTLPProfilingExporter implements ProfilingExporter {
       },
     ];
     encode(serialize(profile, { samplingPeriodMillis: callstackInterval }))
-      .then(serializedProfile => {
-        const logs = [serializedProfile].map(st => {
+      .then((serializedProfile) => {
+        const logs = [serializedProfile].map((st) => {
           return {
             name: 'otel.profiling',
             body: { stringValue: st.toString('base64') },

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -33,7 +33,7 @@ const detectors = [
 
 export const detect = (): Resource => {
   return detectors
-    .map(detector => {
+    .map((detector) => {
       try {
         return detector.detect();
       } catch (e) {

--- a/src/start.ts
+++ b/src/start.ts
@@ -76,7 +76,7 @@ export const stop = async () => {
 
   if (running.metrics) {
     promises.push(
-      new Promise<void>(resolve => {
+      new Promise<void>((resolve) => {
         running.metrics!.stopMetrics();
         resolve();
       })
@@ -91,7 +91,7 @@ export const stop = async () => {
 
   if (running.profiling) {
     promises.push(
-      new Promise<void>(resolve => {
+      new Promise<void>((resolve) => {
         running.profiling!.stop();
         resolve();
       })

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -141,7 +141,7 @@ async function shutdownGlobalTracerProvider() {
     reportedConstructor = delegate?.constructor;
 
     if (isShutDownable(delegate)) {
-      return delegate.shutdown().catch(e => {
+      return delegate.shutdown().catch((e) => {
         diag.warn('OpenTelemetry: error shutting down tracer provider', e);
       });
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,7 +72,7 @@ export function deduplicate(arr: string[]) {
 }
 
 const formatStringSet = (set: Set<string> | string[]) => {
-  return [...set.values()].map(item => `"${item}"`).join(', ');
+  return [...set.values()].map((item) => `"${item}"`).join(', ');
 };
 
 export function assertNoExtraneousProperties(

--- a/test/instrumentation/redis.test.ts
+++ b/test/instrumentation/redis.test.ts
@@ -32,9 +32,9 @@ describe('Redis instrumentation', () => {
   let spanProcessor: SpanProcessor;
 
   before(() => {
-    redisServer = net.createServer(socket => {
+    redisServer = net.createServer((socket) => {
       let data = '';
-      socket.on('data', d => {
+      socket.on('data', (d) => {
         data += d;
 
         if (data.endsWith('bar\r\n')) {
@@ -64,12 +64,12 @@ describe('Redis instrumentation', () => {
     serviceName: 'test-service',
     instrumentations: [new RedisInstrumentation()],
     spanExporterFactory: () => exporter,
-    spanProcessorFactory: options => {
+    spanProcessorFactory: (options) => {
       return (spanProcessor = defaultSpanProcessorFactory(options));
     },
   });
 
-  it('db statement is not added by default', done => {
+  it('db statement is not added by default', (done) => {
     startTracing(testOpts());
     const client = require('redis').createClient({
       no_ready_check: true,
@@ -83,7 +83,7 @@ describe('Redis instrumentation', () => {
     });
   });
 
-  it('db statement is not added when SPLUNK_REDIS_INCLUDE_COMMAND_ARGS is false', done => {
+  it('db statement is not added when SPLUNK_REDIS_INCLUDE_COMMAND_ARGS is false', (done) => {
     process.env.SPLUNK_REDIS_INCLUDE_COMMAND_ARGS = 'false';
     startTracing(testOpts());
     const client = require('redis').createClient({
@@ -98,7 +98,7 @@ describe('Redis instrumentation', () => {
     });
   });
 
-  it('db statement is added when setting SPLUNK_REDIS_INCLUDE_COMMAND_ARGS env var', done => {
+  it('db statement is added when setting SPLUNK_REDIS_INCLUDE_COMMAND_ARGS env var', (done) => {
     process.env.SPLUNK_REDIS_INCLUDE_COMMAND_ARGS = 'true';
     startTracing(testOpts());
     const client = require('redis').createClient({

--- a/test/instrumentations.test.ts
+++ b/test/instrumentations.test.ts
@@ -26,7 +26,7 @@ describe('instrumentations', () => {
     const inst = instrumentations.getInstrumentations();
     // Note: the list here is the instrumentations among devDependencies
     assert.deepEqual(
-      inst.map(i => i.instrumentationName),
+      inst.map((i) => i.instrumentationName),
       [
         '@opentelemetry/instrumentation-bunyan',
         '@opentelemetry/instrumentation-http',
@@ -60,7 +60,7 @@ describe('instrumentations', () => {
   it('loader imports and returns object when package is available', () => {
     const HttpInstrumentation = function () {};
     const loader = rewire('../src/instrumentations/loader');
-    const revert = loader.__set__('require', module => {
+    const revert = loader.__set__('require', (module) => {
       return { HttpInstrumentation };
     });
 

--- a/test/loginjection.test.ts
+++ b/test/loginjection.test.ts
@@ -53,7 +53,7 @@ describe('log injection', () => {
 
   beforeEach(() => {
     stream = new Writable({
-      write: chunk => {
+      write: (chunk) => {
         record = JSON.parse(chunk);
       },
     });

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -49,7 +49,7 @@ describe('metrics', () => {
   describe('native counters collection', () => {
     const { metrics } = require('../src/native_ext');
 
-    it('is possible to get native counters', done => {
+    it('is possible to get native counters', (done) => {
       const stats = metrics.collect();
       assert.deepStrictEqual(stats, emptyStats());
 
@@ -66,7 +66,7 @@ describe('metrics', () => {
       assert.deepStrictEqual(metrics.collect(), emptyStats());
     });
 
-    it('does not compute event loop lag to be less than the actual execution time', done => {
+    it('does not compute event loop lag to be less than the actual execution time', (done) => {
       metrics.reset();
       const begin = hrtime();
 
@@ -155,18 +155,18 @@ describe('metrics', () => {
   });
 
   describe('startMetrics', () => {
-    it('exports metrics', done => {
+    it('exports metrics', (done) => {
       const metric =
         (name: string) =>
         ({ metric }) =>
           metric === name;
-      const gcMetric = (name: string) => m =>
+      const gcMetric = (name: string) => (m) =>
         metric(name)(m) && m.dimensions['gctype'] === 'all';
       const { stopMetrics } = startMetrics({
         exportInterval: 100,
         signalfx: {
           client: {
-            send: report => {
+            send: (report) => {
               stopMetrics();
               const gauges = report.gauges;
               const cumulativeCounters = report.cumulative_counters;

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -279,5 +279,5 @@ function testSpanProcessorFactory(options: Options): SpanProcessor {
 }
 
 function testPropagatorFactory(options: Options): api.TextMapPropagator {
-  return new HttpBaggagePropagator();
+  return new W3CBaggagePropagator();
 }

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -110,10 +110,10 @@ describe('options', () => {
 
       // resource attributes for process, host and os are different at each run, iterate through them, make sure they exist and then delete
       Object.keys(options.tracerConfig.resource.attributes)
-        .filter(attribute => {
+        .filter((attribute) => {
           return expectedAttributes.has(attribute);
         })
-        .forEach(processAttribute => {
+        .forEach((processAttribute) => {
           assert(options.tracerConfig.resource.attributes[processAttribute]);
           delete options.tracerConfig.resource.attributes[processAttribute];
         });

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -36,7 +36,7 @@ import { detect as detectResource } from '../../src/resource';
 import * as utils from '../utils';
 
 const sleep = (ms: number) => {
-  return new Promise(r => setTimeout(r, ms));
+  return new Promise((r) => setTimeout(r, ms));
 };
 
 describe('profiling', () => {

--- a/test/propagation.test.ts
+++ b/test/propagation.test.ts
@@ -154,7 +154,7 @@ describe('propagation', () => {
     let spanProcessor: SpanProcessor;
     startTracing({
       spanExporterFactory: () => exporter,
-      spanProcessorFactory: options => {
+      spanProcessorFactory: (options) => {
         return (spanProcessor = defaultSpanProcessorFactory(options));
       },
     });

--- a/test/servertiming.test.ts
+++ b/test/servertiming.test.ts
@@ -52,18 +52,18 @@ describe('servertiming', () => {
       res.end('ok');
     });
     server.listen(PORT);
-    http.get(SERVER_URL, res => {
+    http.get(SERVER_URL, (res) => {
       assertHeaders(spanContext, res);
       done();
     });
   }
 
-  it('injects server timing by default', done => {
+  it('injects server timing by default', (done) => {
     startTracing({});
     testHeadersAdded(done);
   });
 
-  it('can be enabled via environment variables', done => {
+  it('can be enabled via environment variables', (done) => {
     process.env.SPLUNK_TRACE_RESPONSE_HEADER_ENABLED = 'true';
     startTracing({});
     testHeadersAdded(() => {
@@ -71,12 +71,12 @@ describe('servertiming', () => {
     });
   });
 
-  it('injects server timing header with current context', done => {
+  it('injects server timing header with current context', (done) => {
     startTracing({ serverTimingEnabled: true });
     testHeadersAdded(done);
   });
 
-  it('works with user provided http instrumentation config', done => {
+  it('works with user provided http instrumentation config', (done) => {
     startTracing({
       serverTimingEnabled: true,
       instrumentations: [new HttpInstrumentation({})],
@@ -85,7 +85,7 @@ describe('servertiming', () => {
     testHeadersAdded(done);
   });
 
-  it('leaves user hooks unchanged', done => {
+  it('leaves user hooks unchanged', (done) => {
     let userHookCalled = false;
 
     startTracing({
@@ -106,7 +106,7 @@ describe('servertiming', () => {
       res.end('ok');
     });
     server.listen(PORT);
-    http.get(SERVER_URL, res => {
+    http.get(SERVER_URL, (res) => {
       assertHeaders(spanContext, res);
       assert.ok(userHookCalled);
       done();

--- a/test/uri_parameter_capture.test.ts
+++ b/test/uri_parameter_capture.test.ts
@@ -64,7 +64,7 @@ describe('Capturing URI parameters', () => {
 
   const testOpts = () => ({
     spanExporterFactory: () => exporter,
-    spanProcessorFactory: options => {
+    spanProcessorFactory: (options) => {
       return (spanProcessor = defaultSpanProcessorFactory(options));
     },
   });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const isConfigVarEntry = key => {
+const isConfigVarEntry = (key) => {
   const lowercased = key.toLowerCase();
   return (
     lowercased.includes('splunk_') ||
@@ -35,7 +35,7 @@ const isConfigVarEntry = key => {
 export const cleanEnvironment = () => {
   Object.keys(process.env)
     .filter(isConfigVarEntry)
-    .forEach(key => {
+    .forEach((key) => {
       delete process.env[key];
     });
 };


### PR DESCRIPTION
# Description

Current formatting rules deny parentheses around arrow function arguments, which means that the formating is different for functions that have 1 argument compared to when it has 0 or 2+. That has been annoying for me during dev. Please consider changing the lint rule.

Seems like it should be [prettier default](https://prettier.io/docs/en/options.html#arrow-function-parentheses), but for some reason(`gts`?) didn't apply to us.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Internal change (a change which is not visible to the package consumers)
- [ ] Documentation change or requires a documentation update

# Checklist:

- [ ] Unit tests have been added/updated
- [ ] Documentation has been updated
- [ ] Change file has been generated (`npm run change:new`)
- [ ] Delete this branch (after the PR is merged)
