### PR TITLE
fix: add compilation support for older (<8) GCC versions

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -21,9 +21,7 @@
           "-Werror"
         ],
         "cflags_cc": [
-          "-Wno-unknown-warning",
-          "-Wno-missing-attributes",
-          "-Wno-cast-function-type"
+          "-Wno-attributes"
         ]
       }],
       ["OS == 'win'", {

--- a/binding.gyp
+++ b/binding.gyp
@@ -21,6 +21,8 @@
           "-Werror"
         ],
         "cflags_cc": [
+          "-Wno-unknown-warning",
+          "-Wno-missing-attributes",
           "-Wno-cast-function-type"
         ]
       }],

--- a/src/native_ext/ext.h
+++ b/src/native_ext/ext.h
@@ -1,6 +1,12 @@
 #pragma once
 
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__)
+  #define GCC_VERSION (__GNUC__ * 10000 \
+                      + __GNUC_MINOR__ * 100 \
+                      + __GNUC_PATCHLEVEL__)
+#endif
+
+#if (defined(__GNUC__) && GCC_VERSION >= 40900) || defined(__clang__)
 #define SPLK_ASSUME_ALIGNED(n) __attribute__((assume_aligned(n)))
 #else
 #define SPLK_ASSUME_ALIGNED(n)

--- a/src/native_ext/ext.h
+++ b/src/native_ext/ext.h
@@ -1,13 +1,20 @@
 #pragma once
 
 #if defined(__GNUC__)
-  #define GCC_VERSION (__GNUC__ * 10000 \
-                      + __GNUC_MINOR__ * 100 \
-                      + __GNUC_PATCHLEVEL__)
+#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
 
 #if (defined(__GNUC__) && GCC_VERSION >= 40900) || defined(__clang__)
 #define SPLK_ASSUME_ALIGNED(n) __attribute__((assume_aligned(n)))
 #else
 #define SPLK_ASSUME_ALIGNED(n)
+#endif
+
+#if defined(__GNUC__) && GCC_VERSION >= 80000
+#define SPLK_BEGIN_IGNORE_CAST_FUNCTION_TYPE_WARNING                                               \
+  _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wcast-function-type\"")
+#define SPLK_END_IGNORE_CAST_FUNCTION_TYPE_WARNING _Pragma("GCC diagnostic pop")
+#else
+#define SPLK_BEGIN_IGNORE_CAST_FUNCTION_TYPE_WARNING
+#define SPLK_END_IGNORE_CAST_FUNCTION_TYPE_WARNING
 #endif

--- a/src/native_ext/metrics.h
+++ b/src/native_ext/metrics.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <v8.h>
+#include "splunk_v8.h"
 
 namespace Splunk {
 namespace Metrics {

--- a/src/native_ext/module.cpp
+++ b/src/native_ext/module.cpp
@@ -1,3 +1,4 @@
+#include "ext.h"
 #include "metrics.h"
 #include "profiling.h"
 #include <nan.h>
@@ -11,4 +12,13 @@ NAN_MODULE_INIT(Init) {
 
 } // namespace
 
+#if (defined(__GNUC__) && GCC_VERSION >= 80000)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
+
 NODE_MODULE(NODE_GYP_MODULE_NAME, Init);
+
+#if (defined(__GNUC__) && GCC_VERSION >= 80000)
+#pragma GCC diagnostic pop
+#endif

--- a/src/native_ext/module.cpp
+++ b/src/native_ext/module.cpp
@@ -1,4 +1,3 @@
-#include "ext.h"
 #include "metrics.h"
 #include "profiling.h"
 #include <nan.h>
@@ -12,13 +11,6 @@ NAN_MODULE_INIT(Init) {
 
 } // namespace
 
-#if (defined(__GNUC__) && GCC_VERSION >= 80000)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-function-type"
-#endif
-
+SPLK_BEGIN_IGNORE_CAST_FUNCTION_TYPE_WARNING
 NODE_MODULE(NODE_GYP_MODULE_NAME, Init);
-
-#if (defined(__GNUC__) && GCC_VERSION >= 80000)
-#pragma GCC diagnostic pop
-#endif
+SPLK_END_IGNORE_CAST_FUNCTION_TYPE_WARNING

--- a/src/native_ext/profiling.h
+++ b/src/native_ext/profiling.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <v8.h>
+#include "splunk_v8.h"
 
 namespace Splunk {
 namespace Profiling {

--- a/src/native_ext/splunk_v8.h
+++ b/src/native_ext/splunk_v8.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "ext.h"
+
+SPLK_BEGIN_IGNORE_CAST_FUNCTION_TYPE_WARNING
+#include <v8.h>
+SPLK_END_IGNORE_CAST_FUNCTION_TYPE_WARNING


### PR DESCRIPTION
Older GCC versions don't support `-Wno-cast-function-type` which is needed to include either `v8` or `nan` due to these causing warnings (which we take as errors). Resolved it with pragmas and a compiler version check.

`-Wno-attributes` is used to get rid of unknown (to GCC 4.x) deprecation attributes, e.g. `[[deprecated]]`.


Fixes https://github.com/signalfx/splunk-otel-js/issues/546