### PR TITLE
chore: add Centos 7 to CI checks, parallelize CI

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,7 +1,6 @@
 name: Check Links
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,7 +1,6 @@
 name: Check Links
 
-on:
-  pull_request:
+on: pull_request
 
 jobs:
   linkChecker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,59 +10,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        container: ['node:14.0.0']
+        node_api_target: ['14.0.0', '15.0.0', '16.0.0', '17.0.1', '18.0.0']
         include:
           - container: node:12.13.0
-            versions: '12.13.0 13.0.0'
-            label: node12
-          - container: node:14.0.0
-            versions: '14.0.0 15.0.0 16.0.0 17.0.1 18.0.0'
-            label: node14
+            node_api_target: '12.13.0'
+          - container: node:12.13.0
+            node_api_target: '13.0.0'
     container: ${{ matrix.container }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
       - name: Install npm dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Prebuild
-        run: npm run prebuild:os ${{ matrix.versions }}
-      - name: Run tests
-        run: npm run test
+        run: npm run prebuild:os ${{ matrix.node_api_target }}
       - name: upload prebuilds
         uses: actions/upload-artifact@v3
         with:
-          name: prebuilds-linux-${{ matrix.label }}
+          name: prebuilds-linux
           path: prebuilds
 
-  prebuilds:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows-2019
-            label: windows
-          - os: macos-11
-            label: macos
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-      - name: Install npm dependencies
-        run: npm ci
-      - name: Prebuild
-        run: npm run prebuild:os
-      - name: Run tests
-        run: npm run test
-      - name: upload prebuilds
-        uses: actions/upload-artifact@v3
-        with:
-          name: prebuilds-${{ matrix.label }}
-          path: prebuilds
-
-  prebuilds-parallel:
+  prebuilds-macos-windows:
     strategy:
       fail-fast: false
       matrix:
@@ -74,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Install npm dependencies
         run: npm ci --ignore-scripts
       - name: Prebuild
@@ -82,27 +52,27 @@ jobs:
       - name: upload prebuilds
         uses: actions/upload-artifact@v3
         with:
-          name: parallel-prebuilds-${{ matrix.label }}
+          name: prebuilds-macos-windows
           path: prebuilds
 
   create-package:
-    needs: [prebuilds-linux, prebuilds]
+    needs: [prebuilds-linux, prebuilds-macos-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
       - name: download prebuilds
         uses: actions/download-artifact@v3
       - name: copy prebuilds
         run: |
           mkdir -p prebuilds
-          cp -r prebuilds-linux-node12/* prebuilds
-          cp -r prebuilds-linux-node14/* prebuilds
-          cp -r prebuilds-windows/* prebuilds
-          cp -r prebuilds-macos/* prebuilds
+          cp -r prebuilds-linux/* prebuilds
+          cp -r prebuilds-macos-windows/* prebuilds
       - name: Install npm dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Build
         run: npm run compile
       - name: Pack
@@ -116,9 +86,7 @@ jobs:
           path: ${{ steps.pack.outputs.package_file }}
 
   unit-tests:
-    needs: [prebuilds-linux, prebuilds]
     runs-on: ${{ matrix.os }}
-    permissions: read-all
     strategy:
       fail-fast: false
       matrix:
@@ -135,7 +103,7 @@ jobs:
       - name: Test
         run: npm run test
       - name: Report Coverage
-        if: ${{matrix.nodejs == '14' && matrix.os == 'ubuntu-latest'}}
+        if: ${{matrix.nodejs == '16' && matrix.os == 'ubuntu-latest'}}
         uses: codecov/codecov-action@v3
         with:
           verbose: true
@@ -143,7 +111,6 @@ jobs:
   lint:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    permissions: read-all
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -165,7 +132,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    permissions: read-all
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -206,7 +172,6 @@ jobs:
 
   e2e-published:
     runs-on: ubuntu-latest
-    permissions: read-all
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -232,7 +197,6 @@ jobs:
 
   e2e-local:
     runs-on: ubuntu-latest
-    permissions: read-all
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,14 +164,17 @@ jobs:
         nodejs: [12, 14, 16, 18]
         include:
           - container: 'centos:7'
-          - cmd: 'curl -sL https://rpm.nodesource.com/setup_${{ matrix.nodejs }}.x | bash - && yum install -y nodejs gcc-c++ make'
+          - cmd: 'curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - && yum install -y nodejs gcc-c++ make'
     container: ${{ matrix.container }}
+    env:
+      NODE_VERSION: ${{ matrix.nodejs }}
     steps:
       - name: Setup container
         run: ${{ matrix.cmd }}
       - name: Debug
         run: |
           rpm --query centos-release
+          echo $NODE_VERSION
           node --version
           npm --version
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     container: ${{ matrix.container }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
       - name: Install npm dependencies
         run: npm ci
       - name: Prebuild
@@ -29,7 +29,7 @@ jobs:
       - name: Run tests
         run: npm run test
       - name: upload prebuilds
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: prebuilds-linux-${{ matrix.label }}
           path: prebuilds
@@ -46,8 +46,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - name: Install npm dependencies
@@ -57,7 +57,7 @@ jobs:
       - name: Run tests
         run: npm run test
       - name: upload prebuilds
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: prebuilds-${{ matrix.label }}
           path: prebuilds
@@ -67,10 +67,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
       - name: download prebuilds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: copy prebuilds
         run: |
           mkdir -p prebuilds
@@ -87,7 +87,7 @@ jobs:
         run: |
           echo "::set-output name=package_file::$(npm pack)"
       - name: Upload package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.pack.outputs.package_file }}
           path: ${{ steps.pack.outputs.package_file }}
@@ -103,8 +103,8 @@ jobs:
         nodejs: ['12.13', '14', '16', '17', '18']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.nodejs }}
       - name: Install npm dependencies
@@ -113,7 +113,7 @@ jobs:
         run: npm run test
       - name: Report Coverage
         if: ${{matrix.nodejs == '14' && matrix.os == 'ubuntu-latest'}}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           verbose: true
 
@@ -123,10 +123,10 @@ jobs:
     permissions: read-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch base_ref
         run: git fetch origin ${{ github.base_ref }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: Install npm dependencies
@@ -145,10 +145,10 @@ jobs:
     permissions: read-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: Install npm dependencies
@@ -186,7 +186,7 @@ jobs:
     permissions: read-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get versions
         run: |
           docker-compose --version;
@@ -212,7 +212,7 @@ jobs:
     permissions: read-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Test basic example
         working-directory: test/examples
         run: docker-compose -f e2e.docker-compose.yml up --exit-code-from test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
         nodejs: [12, 14, 16, 18]
         include:
           - container: 'centos:7'
-          - cmd: 'curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - && yum install -y nodejs gcc-c++ make'
+          - cmd: 'curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - && yum install -y nodejs gcc-c++ make python3'
     container: ${{ matrix.container }}
     env:
       NODE_VERSION: ${{ matrix.nodejs }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,9 +161,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - container: centos:7
-            #cmd: 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs gcc-c++ make'
-            nodejs: ['12.13', 14, 16, 18]
+          container: ['centos:7']
+          nodejs: ['12.13', 14, 16, 18]
+          #cmd: 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs gcc-c++ make'
     container: ${{ matrix.container }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,29 @@ jobs:
           name: prebuilds-${{ matrix.label }}
           path: prebuilds
 
+  prebuilds-parallel:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2019, macos-11]
+        node_api_target: ['12.0.0', '13.0.0', '14.0.0', '15.0.0', '16.0.0', '17.0.1', '18.0.0']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+      - name: Install npm dependencies
+        run: npm ci --ignore-scripts
+      - name: Prebuild
+        run: npm run prebuild:os ${{ matrix.node_api_target }}
+      - name: upload prebuilds
+        uses: actions/upload-artifact@v3
+        with:
+          name: parallel-prebuilds-${{ matrix.label }}
+          path: prebuilds
+
   create-package:
     needs: [prebuilds-linux, prebuilds]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,18 +172,20 @@ jobs:
 
   e2e-published:
     runs-on: ubuntu-latest
-    matrix:
-      include:
-        - target: ''
-          name: 'Basic'
-        - target: '-f express.override.yml'
-          name: 'Express'
-        - target: '-f mixed.override.yml'
-          name: 'Mixed'
-        - target: '-f log-injection.override.yml'
-          name: 'Log injection'
-        - target: '-f profiling.override.yml'
-          name: 'Profiling'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: ''
+            name: 'Basic'
+          - target: '-f express.override.yml'
+            name: 'Express'
+          - target: '-f mixed.override.yml'
+            name: 'Mixed'
+          - target: '-f log-injection.override.yml'
+            name: 'Log injection'
+          - target: '-f profiling.override.yml'
+            name: 'Profiling'
     name: e2e published ${{ matrix.name }}
     steps:
       - name: Checkout
@@ -198,18 +200,20 @@ jobs:
 
   e2e-local:
     runs-on: ubuntu-latest
-    matrix:
-      include:
-        - target: ''
-          name: 'Basic'
-        - target: '-f express.override.yml'
-          name: 'Express'
-        - target: '-f mixed.override.yml'
-          name: 'Mixed'
-        - target: '-f log-injection.override.yml'
-          name: 'Log injection'
-        - target: '-f profiling.override.yml'
-          name: 'Profiling'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: ''
+            name: 'Basic'
+          - target: '-f express.override.yml'
+            name: 'Express'
+          - target: '-f mixed.override.yml'
+            name: 'Mixed'
+          - target: '-f log-injection.override.yml'
+            name: 'Log injection'
+          - target: '-f profiling.override.yml'
+            name: 'Profiling'
     name: e2e local ${{ matrix.name }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: Continuous Integration
 on:
-  pull_request:
   push:
 permissions: read-all
 
@@ -107,28 +106,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           verbose: true
-
-  lint:
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Fetch base_ref
-        run: git fetch origin ${{ github.base_ref }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: Install npm dependencies
-        run: npm ci
-      - name: Check version
-        run: npm run version:check
-      - name: Lint code
-        run: npm run lint
-      - name: Lint commits
-        run: npm run lint:commits -- --from origin/${{ github.base_ref }}
-      - name: Verify changes
-        run: npm run change:check
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          container: ['centos:7']
-          nodejs: ['12.13', 14, 16, 18]
-          #cmd: 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs gcc-c++ make'
+        container: ['centos:7']
+        nodejs: ['12.13', 14, 16, 18]
+        #cmd: 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs gcc-c++ make'
     container: ${{ matrix.container }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,25 +159,23 @@ jobs:
   platform-check:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        container: ['centos:7']
-        nodejs: ['12.13', 14, 16, 18]
-        #cmd: 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs gcc-c++ make'
+        nodejs: [12, 14, 16, 18]
+        include:
+          - container: 'centos:7'
+          - cmd: 'curl -sL https://rpm.nodesource.com/setup_${{ matrix.nodejs }}.x | bash - && yum install -y nodejs gcc-c++ make'
     container: ${{ matrix.container }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Node.js ${{ matrix.nodejs }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.nodejs }}
+      - name: Setup container
+        run: ${{ matrix.cmd }}
       - name: Debug
         run: |
           rpm --query centos-release
           node --version
           npm --version
-      #- name: Setup container
-      #  run: ${{ matrix.cmd }}
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Install npm dependencies
         run: npm ci
       - name: Compile native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,15 +163,17 @@ jobs:
         include:
           - container: centos:7
             #cmd: 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs gcc-c++ make'
-            node-version: [12.x, 14.x, 16.x, 18.x]
+            node-version: [12, 14, 16, 18]
     container: ${{ matrix.container }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: |
+      - name: Debug
+        run: |
           rpm --query centos-release
           node --version
           npm --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: Continuous Integration
-on:
-  push:
+on: push
 permissions: read-all
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,19 @@ jobs:
 
   e2e-published:
     runs-on: ubuntu-latest
+    matrix:
+      include:
+        - target: ''
+          name: 'Basic'
+        - target: '-f express.override.yml'
+          name: 'Express'
+        - target: '-f mixed.override.yml'
+          name: 'Mixed'
+        - target: '-f log-injection.override.yml'
+          name: 'Log injection'
+        - target: '-f profiling.override.yml'
+          name: 'Profiling'
+    name: e2e published ${{ matrix.name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -179,39 +192,28 @@ jobs:
         run: |
           docker-compose --version;
           docker --version;
-      - name: Test basic example
+      - name: Test ${{ matrix.name }} example
         working-directory: test/examples
-        run: docker-compose -f e2e.docker-compose.yml -f published.override.yml up --exit-code-from test
-      - name: Test express example
-        working-directory: test/examples
-        run: docker-compose -f e2e.docker-compose.yml -f express.override.yml -f published.override.yml up --exit-code-from test
-      - name: Test mixed example
-        working-directory: test/examples
-        run: docker-compose -f e2e.docker-compose.yml -f mixed.override.yml -f published.override.yml up --exit-code-from test
-      - name: Test log-injection example
-        working-directory: test/examples
-        run: docker-compose -f e2e.docker-compose.yml -f log-injection.override.yml -f published.override.yml up --exit-code-from test
-      - name: Test profiling example
-        working-directory: test/examples
-        run: docker-compose -f e2e.docker-compose.yml -f profiling.override.yml -f published.override.yml up --exit-code-from test
+        run: docker-compose -f e2e.docker-compose.yml ${{ matrix.target }} -f published.override.yml up --exit-code-from test
 
   e2e-local:
     runs-on: ubuntu-latest
+    matrix:
+      include:
+        - target: ''
+          name: 'Basic'
+        - target: '-f express.override.yml'
+          name: 'Express'
+        - target: '-f mixed.override.yml'
+          name: 'Mixed'
+        - target: '-f log-injection.override.yml'
+          name: 'Log injection'
+        - target: '-f profiling.override.yml'
+          name: 'Profiling'
+    name: e2e local ${{ matrix.name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Test basic example
+      - name: Test ${{ matrix.name }} example
         working-directory: test/examples
-        run: docker-compose -f e2e.docker-compose.yml up --exit-code-from test
-      - name: Test express example
-        working-directory: test/examples
-        run: docker-compose -f e2e.docker-compose.yml -f express.override.yml up --exit-code-from test
-      - name: Test mixed example
-        working-directory: test/examples
-        run: docker-compose -f e2e.docker-compose.yml -f mixed.override.yml up --exit-code-from test
-      - name: Test log-injection example
-        working-directory: test/examples
-        run: docker-compose -f e2e.docker-compose.yml -f log-injection.override.yml up --exit-code-from test
-      - name: Test profiling example
-        working-directory: test/examples
-        run: docker-compose -f e2e.docker-compose.yml -f profiling.override.yml up --exit-code-from test
+        run: docker-compose -f e2e.docker-compose.yml ${{ matrix.target }} up --exit-code-from test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,15 +163,15 @@ jobs:
         include:
           - container: centos:7
             #cmd: 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs gcc-c++ make'
-            node-version: [12, 14, 16, 18]
+            nodejs: ['12.13', 14, 16, 18]
     container: ${{ matrix.container }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js ${{ matrix.nodejs }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.nodejs }}
       - name: Debug
         run: |
           rpm --query centos-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
         include:
           - container: 'centos:7'
           - cmd: 'curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - && yum install -y nodejs gcc-c++ make'
-    name: Platform check: ${{ matrix.container }}, Node.js ${{ matrix.nodejs }}
+    name: Platform check - ${{ matrix.container }} - Node.js ${{ matrix.nodejs }}
     container: ${{ matrix.container }}
     env:
       NODE_VERSION: ${{ matrix.nodejs }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,8 @@ jobs:
     container: ${{ matrix.container }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,18 +165,13 @@ jobs:
         include:
           - container: 'centos:7'
           - cmd: 'curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - && yum install -y nodejs gcc-c++ make'
+    name: Platform check: ${{ matrix.container }}, Node.js ${{ matrix.nodejs }}
     container: ${{ matrix.container }}
     env:
       NODE_VERSION: ${{ matrix.nodejs }}
     steps:
       - name: Setup container
         run: ${{ matrix.cmd }}
-      - name: Debug
-        run: |
-          rpm --query centos-release
-          echo $NODE_VERSION
-          node --version
-          npm --version
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install npm dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,8 @@ jobs:
         run: npm ci
       - name: Check version
         run: npm run version:check
+      - name: Lint code
+        run: npm run lint
       - name: Lint commits
         run: npm run lint:commits -- --from origin/${{ github.base_ref }}
       - name: Verify changes
@@ -151,10 +153,29 @@ jobs:
           node-version: 16
       - name: Install npm dependencies
         run: npm ci
-      - name: Lint code
-        run: npm run lint
       - name: Build
         run: npm run compile
+
+  platform-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - container: centos:7
+            cmd: 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs gcc-c++ make'
+    container: ${{ matrix.container }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup container
+        run: ${{ matrix.cmd }}
+      - uses: actions/setup-node@v2
+      - name: Install npm dependencies
+        run: npm ci
+      - name: Compile native
+        run: npm run prebuild:current
+      - name: Run tests
+        run: npm run test
 
   e2e-published:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,14 +162,21 @@ jobs:
       matrix:
         include:
           - container: centos:7
-            cmd: 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs gcc-c++ make'
+            #cmd: 'curl -sL https://rpm.nodesource.com/setup_14.x | bash - && yum install -y nodejs gcc-c++ make'
+            node-version: [12.x, 14.x, 16.x, 18.x]
     container: ${{ matrix.container }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup container
-        run: ${{ matrix.cmd }}
       - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: |
+          rpm --query centos-release
+          node --version
+          npm --version
+      #- name: Setup container
+      #  run: ${{ matrix.cmd }}
       - name: Install npm dependencies
         run: npm ci
       - name: Compile native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,10 +161,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nodejs: [12, 14, 16, 18]
+        nodejs: [12, 14]
         include:
           - container: 'centos:7'
-          - cmd: 'curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - && yum install -y nodejs gcc-c++ make python3'
+          - cmd: 'curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - && yum install -y nodejs gcc-c++ make'
     container: ${{ matrix.container }}
     env:
       NODE_VERSION: ${{ matrix.nodejs }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,5 @@
 name: Lint
-on:
-  pull_request:
+on: pull_request
 permissions: read-all
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+on:
+  pull_request:
+permissions: read-all
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Fetch base_ref
+        run: git fetch origin ${{ github.base_ref }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install npm dependencies
+        run: npm ci --ignore-scripts
+      - name: Check version
+        run: npm run version:check
+      - name: Lint code
+        run: npm run lint
+      - name: Lint commits
+        run: npm run lint:commits -- --from origin/${{ github.base_ref }}
+      - name: Verify changes
+        run: npm run change:check


### PR DESCRIPTION
Added CentOS 7 compilation and tests.

Additionally:
* The CI was taking a bit too long, so parallelized all the possible workflows.
* Upgraded GitHub Actions tooling
* Move lint and link checks to PR only
* Remove duplicate checks by running the same CI both on pushes and PRs
https://www.youtube.com/watch?v=AbSehcT19u0