### PR TITLE
fix: don't produce error messages when tracing is started before profiling

### DIFF
--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -115,7 +115,7 @@ export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
 
   if (isTracingContextManagerEnabled()) {
     diag.warn(
-      `Profiling: unable to set up context manager due to tracing's context manager being active. Traces won't be correlated to profiling data. Please start profiling before tracing.`
+      `Splunk profiling: unable to set up context manager due to tracing's context manager being active. Traces won't be correlated to profiling data. Please start profiling before tracing.`
     );
   } else if (!profilingContextManagerEnabled) {
     const contextManager = new ProfilingContextManager();

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -36,6 +36,7 @@ import {
 import { ProfilingContextManager } from './ProfilingContextManager';
 import { OTLPProfilingExporter } from './OTLPProfilingExporter';
 import { DebugExporter } from './DebugExporter';
+import { isTracingContextManagerEnabled } from '../tracing';
 
 export { ProfilingOptions };
 
@@ -93,6 +94,12 @@ export function defaultExporterFactory(
   return exporters;
 }
 
+let profilingContextManagerEnabled = false;
+
+export function isProfilingContextManagerSet(): boolean {
+  return profilingContextManagerEnabled;
+}
+
 export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
   assertNoExtraneousProperties(opts, allowedProfilingOptions);
 
@@ -106,9 +113,16 @@ export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
     };
   }
 
-  const contextManager = new ProfilingContextManager();
-  contextManager.enable();
-  context.setGlobalContextManager(contextManager);
+  if (isTracingContextManagerEnabled()) {
+    diag.warn(
+      `Profiling: unable to set up context manager due to tracing's context manager being active. Traces won't be correlated to profiling data. Please start profiling before tracing.`
+    );
+  } else if (!profilingContextManagerEnabled) {
+    const contextManager = new ProfilingContextManager();
+    contextManager.enable();
+    context.setGlobalContextManager(contextManager);
+    profilingContextManagerEnabled = true;
+  }
 
   const exporters = options.exporterFactory(options);
 


### PR DESCRIPTION
Previously when profiling and tracing were started, OTel logged a diagnostic error due to an attempt to overwrite the context manager global (which is not possible) in `startTracing`. Disabled setting up tracing's context manager once profiling has been set up.

Additionally when tracing is started there's now a more helpful error message. Note that this case will be impossible with `start` API (which isn't yet properly documented).

Fixes https://github.com/signalfx/splunk-otel-js/issues/534