### PR TITLE
chore: release v1.4.1

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,6 +2,27 @@
   "name": "@splunk/otel",
   "entries": [
     {
+      "date": "Wed, 22 Sep 2022 09:24:01 GMT",
+      "tag": "@splunk/otel_v1.4.1",
+      "version": "1.4.1",
+      "comments": {
+        "patch": [
+          {
+            "author": "siimkallas@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "c3e9267a1bc95c0750fd2d684cb419bd58b4be23",
+            "comment": "chore: upgrade to signalfx 7.5.0"
+          },
+          {
+            "author": "siimkallas@gmail.com",
+            "package": "@splunk/otel",
+            "commit": "dc7c14567d3778fb132115d8f2eac7bdaef69fcf",
+            "comment": "fix: don't produce otel diagnostic error when profiling is started"
+          }
+        ]
+      }
+    },
+    {
       "date": "Mon, 19 Sep 2022 12:41:01 GMT",
       "tag": "@splunk/otel_v1.4.0",
       "version": "1.4.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This log was last generated on Wed, 22 Sep 2022 09:24:01 GMT and should not be m
 Wed, 22 Sep 2022 09:24:01 GMT
 
 - chore: upgrade to signalfx 7.5.0 for Node.js 18 support [#557](https://github.com/signalfx/splunk-otel-js/pull/557)
-- fix: don't log a diagnostic error when profiling is started [#557](https://github.com/signalfx/splunk-otel-js/pull/556)
+- fix: don't log a diagnostic error when profiling is started [#556](https://github.com/signalfx/splunk-otel-js/pull/556)
 
 ## 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Change Log - @splunk/otel
 
-This log was last generated on Mon, 19 Sep 2022 12:41:01 GMT and should not be manually modified.
+This log was last generated on Wed, 22 Sep 2022 09:24:01 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 1.4.1
+
+Wed, 22 Sep 2022 09:24:01 GMT
+
+- chore: upgrade to signalfx 7.5.0 for Node.js 18 support [#557](https://github.com/signalfx/splunk-otel-js/pull/557)
+- fix: don't log a diagnostic error when profiling is started [#557](https://github.com/signalfx/splunk-otel-js/pull/556)
 
 ## 1.4.0
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/instrumentation-http": "^0.28.0",
-    "@splunk/otel": "^1.3.0",
+    "@splunk/otel": "1.4.0",
     "axios": "^0.21.1",
     "express": "^4.17.1"
   }

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation-express": "^0.29.0",
     "@opentelemetry/instrumentation-http": "^0.28.0",
-    "@splunk/otel": "^1.3.0",
+    "@splunk/otel": "1.4.0",
     "axios": "^0.21.1",
     "env-cmd": "^10.1.0",
     "express": "^4.17.1",

--- a/examples/log-injection/package.json
+++ b/examples/log-injection/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/instrumentation-pino": "^0.29.0",
-    "@splunk/otel": "1.3.0",
+    "@splunk/otel": "1.4.0",
     "pino": "^6.13.3"
   }
 }

--- a/examples/logs/package.json
+++ b/examples/logs/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
-    "@splunk/otel": "^1.3.0"
+    "@splunk/otel": "1.4.0"
   }
 }

--- a/examples/mixed/package.json
+++ b/examples/mixed/package.json
@@ -9,7 +9,7 @@
     "@opentelemetry/api": "^1.0.3",
     "@opentelemetry/instrumentation-http": "^0.28.0",
     "@opentelemetry/instrumentation-pino": "^0.29.0",
-    "@splunk/otel": "^1.3.0",
+    "@splunk/otel": "1.4.0",
     "pino": "^6.13.2"
   }
 }

--- a/examples/profiling/package.json
+++ b/examples/profiling/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.1.0",
-    "@splunk/otel": "1.3.0"
+    "@splunk/otel": "1.4.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '1.4.0';
+export const VERSION = '1.4.1';


### PR DESCRIPTION
- chore: upgrade to signalfx 7.5.0 for Node.js 18 support [#557](https://github.com/signalfx/splunk-otel-js/pull/557)
- fix: don't log a diagnostic error when profiling is started [#556](https://github.com/signalfx/splunk-otel-js/pull/556)