### PR TITLE
doc: add link to 1.x docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 # Splunk Distribution of OpenTelemetry for Node.js
 
+## **Documentation for the current stable version (1.x) can be viewed [here](https://github.com/signalfx/splunk-otel-js/tree/1.x).**
+
 The Splunk Distribution of [OpenTelemetry JS](https://github.com/open-telemetry/opentelemetry-js) automatically instruments your Node application to capture and report distributed traces to Splunk APM.
 
 This Splunk distribution comes with the following defaults:


### PR DESCRIPTION
The main branch will start to slightly differ documentation wise.