### PR TITLE
feat(v1): deprecate Jaeger exporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: Continuous Integration
-on: push
+on:
+  push:
+  pull_request:
 permissions: read-all
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -66,9 +66,7 @@ That's it - the telemetry data is now sent to the locally running Opentelemetry 
 
 In order to send traces directly to Splunk Observability Cloud, you need to:
 
-1. Set `OTEL_EXPORTER_OTLP_ENDPOINT` to
-   `https://ingest.<realm>.signalfx.com/v2/trace/otlp` where `<realm>` is your
-   Splunk APM realm (for example, `https://ingest.us0.signalfx.com/v2/trace/otlp`).
+1. Set `SPLUNK_REALM` to your Splunk APM realm (for example, `us0`).
 1. Set the `SPLUNK_ACCESS_TOKEN` to your Splunk Observability Cloud [access token](https://docs.splunk.com/Observability/admin/authentication-tokens/api-access-tokens.html).
 
 ## Automatically instrument an application

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ That's it - the telemetry data is now sent to the locally running Opentelemetry 
 
 In order to send traces directly to Splunk Observability Cloud, you need to:
 
-1. Set `OTEL_TRACES_EXPORTER` to `"jaeger-thrift-splunk"` to use the Jaeger exporter.
-2. Set `OTEL_EXPORTER_JAEGER_ENDPOINT` to
-   `https://ingest.<realm>.signalfx.com/v2/trace` where `realm` is your
-   Splunk APM realm (for example, `https://ingest.us0.signalfx.com/v2/trace`).
-3. Set the `SPLUNK_ACCESS_TOKEN` to your Splunk Observability Cloud [access token](https://docs.splunk.com/Observability/admin/authentication-tokens/api-access-tokens.html).
+1. Set `OTEL_EXPORTER_OTLP_ENDPOINT` to
+   `https://ingest.<realm>.signalfx.com/v2/trace/otlp` where `<realm>` is your
+   Splunk APM realm (for example, `https://ingest.us0.signalfx.com/v2/trace/otlp`).
+1. Set the `SPLUNK_ACCESS_TOKEN` to your Splunk Observability Cloud [access token](https://docs.splunk.com/Observability/admin/authentication-tokens/api-access-tokens.html).
+
 ## Automatically instrument an application
 
 You can use the `-r` CLI flag to preload the instrumentation module and automatically instrument your Node.js application.

--- a/change/@splunk-otel-ea2500da-2998-4119-be1d-6ea0586cff7e.json
+++ b/change/@splunk-otel-ea2500da-2998-4119-be1d-6ea0586cff7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: deprecate jaeger exporter",
+  "packageName": "@splunk/otel",
+  "email": "rauno56@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -25,6 +25,7 @@ This distribution supports all the configuration options supported by the compon
 | `OTEL_ATTRIBUTE_COUNT_LIMIT`                                    |                         | Stable  | Maximum allowed span attribute count
 | `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`                             | `12000`\*               | Stable  | Maximum allowed attribute value size
 | `OTEL_EXPORTER_JAEGER_ENDPOINT`                                 | `http://localhost:14268/v1/traces` or<br>`http://localhost:9080/v1/trace`<br>if `jaeger-thrift-splunk` is used as exporter | Deprecated | HTTP endpoint for Jaeger traces
+| `OTEL_EXPORTER_OTLP_ENDPOINT`<br>`endpoint`                     | `localhost:4317`        | Stable  | The OTLP endpoint to export to. Only OTLP over gRPC is supported.
 | `OTEL_LOG_LEVEL`                                                |                         | Stable  | Log level to use in diagnostics logging. **Does not set the logger.**
 | `OTEL_PROPAGATORS`<br>`propagators`                             | `tracecontext,baggage`  | Stable  | Comma-delimited list of propagators to use. Valid keys: `baggage`, `tracecontext`, `b3multi`, `b3`.
 | `OTEL_RESOURCE_ATTRIBUTES`                                      |                         | Stable  | Comma-separated list of resource attributes added to every reported span. <details><summary>Example</summary>`key1=val1,key2=val2`</details>

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -24,8 +24,7 @@ This distribution supports all the configuration options supported by the compon
 | --------------------------------------------------------------- | ----------------------- | ------- | ---
 | `OTEL_ATTRIBUTE_COUNT_LIMIT`                                    |                         | Stable  | Maximum allowed span attribute count
 | `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`                             | `12000`\*               | Stable  | Maximum allowed attribute value size
-| `OTEL_EXPORTER_JAEGER_ENDPOINT`                                 | `http://localhost:14268/v1/traces` or<br>`http://localhost:9080/v1/trace`<br>if `jaeger-thrift-splunk` is used as exporter | Stable | HTTP endpoint for Jaeger traces
-| `OTEL_EXPORTER_OTLP_ENDPOINT`<br>`endpoint`                     | `localhost:4317`        | Stable  | The OTLP endpoint to export to. Only OTLP over gRPC is supported.
+| `OTEL_EXPORTER_JAEGER_ENDPOINT`                                 | `http://localhost:14268/v1/traces` or<br>`http://localhost:9080/v1/trace`<br>if `jaeger-thrift-splunk` is used as exporter | Deprecated | HTTP endpoint for Jaeger traces
 | `OTEL_LOG_LEVEL`                                                |                         | Stable  | Log level to use in diagnostics logging. **Does not set the logger.**
 | `OTEL_PROPAGATORS`<br>`propagators`                             | `tracecontext,baggage`  | Stable  | Comma-delimited list of propagators to use. Valid keys: `baggage`, `tracecontext`, `b3multi`, `b3`.
 | `OTEL_RESOURCE_ATTRIBUTES`                                      |                         | Stable  | Comma-separated list of resource attributes added to every reported span. <details><summary>Example</summary>`key1=val1,key2=val2`</details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@opentelemetry/core": "~1.2.0",
         "@opentelemetry/exporter-jaeger": "~1.2.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.28.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.33.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.29.2",
         "@opentelemetry/instrumentation": "^0.28.0",
         "@opentelemetry/propagator-b3": "~1.2.0",
         "@opentelemetry/resources": "~1.2.0",
@@ -1626,90 +1626,91 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.33.0.tgz",
-      "integrity": "sha512-hGf6WMtJpoepHw4kJ4jYsos/45pq6PNHs3pc1PGm+Vbm7e4m6K1j4ZsRAPsWDw4AbYndFJd+u8YjphcPivhxFw==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.29.2.tgz",
+      "integrity": "sha512-fnKOiOzfahHfyi8OekJm/HRoV9VloJ1VmDoxG5PDxdxbJirkZxokJ+mdE/UZ8Z0PSaL/yqPvBkBnaeFyhoEMng==",
       "dependencies": {
         "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.33.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.33.0",
-        "@opentelemetry/otlp-transformer": "0.33.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0"
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/otlp-exporter-base": "0.29.2",
+        "@opentelemetry/otlp-proto-exporter-base": "0.29.2",
+        "@opentelemetry/otlp-transformer": "0.29.2",
+        "@opentelemetry/resources": "1.3.1",
+        "@opentelemetry/sdk-trace-base": "1.3.1",
+        "protobufjs": "^6.9.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
-      "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.33.0.tgz",
-      "integrity": "sha512-st+nsgv23BXSARFwugy6pheulDfOKjIFvzoYOUzPQDVhQtU8+l7dc50rIEybwXghb13o7mZs6Nb8KOvRk57qww==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.29.2.tgz",
+      "integrity": "sha512-tTK+v2ER9Rv7YQXLrCvZpPdNdvZx8TGdZtlK7TKnzpyMRBIf7lqV1Jl0VaHFml+cgVJcGtow/ER6k5uJ5W4kUQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.7.0"
+        "@opentelemetry/core": "1.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
-      "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
       "dependencies": {
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.7.0.tgz",
-      "integrity": "sha512-Iz84C+FVOskmauh9FNnj4+VrA+hG5o+tkMzXuoesvSfunVSioXib0syVFeNXwOm4+M5GdWCuW632LVjqEXStIg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.3.1.tgz",
+      "integrity": "sha512-Or95QZ+9QyvAiwqj+K68z8bDDuyWF50c37w17D10GV1dWzg4Ezcectsu/GB61QcBxm3Y4br0EN5F5TpIFfFliQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/resources": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
-      "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
@@ -1908,166 +1909,138 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.33.0.tgz",
-      "integrity": "sha512-DFJrqp4VoaFmUbo12Nlw9CxxmqQIa6Aq48OR7Ecv4sh3pf8vgztqak76EPIKlSrw2Fpuo352Dw+Y0nnDyEN15Q==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.29.2.tgz",
+      "integrity": "sha512-a46z6yMUzVKrPMbKZLWyO5z+9x1ja7zyS3dlZ1vQLB9fymdsubZsqpCetyh3uSpmfGtHweTie8z0MgR6MMsmiA==",
       "dependencies": {
         "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.33.0",
-        "protobufjs": "7.1.1"
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/otlp-exporter-base": "0.29.2",
+        "protobufjs": "^6.9.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
-      "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.33.0.tgz",
-      "integrity": "sha512-st+nsgv23BXSARFwugy6pheulDfOKjIFvzoYOUzPQDVhQtU8+l7dc50rIEybwXghb13o7mZs6Nb8KOvRk57qww==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.29.2.tgz",
+      "integrity": "sha512-tTK+v2ER9Rv7YQXLrCvZpPdNdvZx8TGdZtlK7TKnzpyMRBIf7lqV1Jl0VaHFml+cgVJcGtow/ER6k5uJ5W4kUQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.7.0"
+        "@opentelemetry/core": "1.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
-      "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/long": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
-    },
-    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/protobufjs": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
-      "integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "node": ">=8.12.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.33.0.tgz",
-      "integrity": "sha512-L4OpsUaki9/Fib17t44YkDvAz3RpMZTtl6hYBhcTqAnqY0wVBpQf0ra25GyHQTKj+oiA//ZxvOlmmM/dXCYxoQ==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.29.2.tgz",
+      "integrity": "sha512-Y6dJj+rhRGynxhLlgEJkdkXuLHdFG8igcSBv6oy3m3GHSSvZkyNV34dVjtZJ586mUXsbFuAf6uqjzteobewO1g==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.33.0",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/sdk-metrics": "0.33.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0"
+        "@opentelemetry/api-metrics": "0.29.2",
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/resources": "1.3.1",
+        "@opentelemetry/sdk-metrics-base": "0.29.2",
+        "@opentelemetry/sdk-trace-base": "1.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-metrics": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz",
-      "integrity": "sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz",
+      "integrity": "sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
-      "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
-      "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
       "dependencies": {
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.7.0.tgz",
-      "integrity": "sha512-Iz84C+FVOskmauh9FNnj4+VrA+hG5o+tkMzXuoesvSfunVSioXib0syVFeNXwOm4+M5GdWCuW632LVjqEXStIg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.3.1.tgz",
+      "integrity": "sha512-Or95QZ+9QyvAiwqj+K68z8bDDuyWF50c37w17D10GV1dWzg4Ezcectsu/GB61QcBxm3Y4br0EN5F5TpIFfFliQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/resources": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
-      "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
@@ -2113,69 +2086,70 @@
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-0.33.0.tgz",
-      "integrity": "sha512-ZXPixOlTd/FHLwpkmm5nTpJE7bZOPfmbSz8hBVFCEHkXE1aKEKaM38UFnZ+2xzOY1tDsDwyxEiiBiDX8y3039A==",
+    "node_modules/@opentelemetry/sdk-metrics-base": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.29.2.tgz",
+      "integrity": "sha512-7hhhZ/6YRRgAXOUTeCsbe6SIk3wZAdAHnEwGGp7aiVH5AOyioHyHInw4EHtowlD6dbLxUWURjh6k+Geht2zbxg==",
+      "deprecated": "Please use @opentelemetry/sdk-metrics",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.33.0",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/resources": "1.7.0",
+        "@opentelemetry/api-metrics": "0.29.2",
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/resources": "1.3.1",
         "lodash.merge": "4.6.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/api-metrics": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz",
-      "integrity": "sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==",
+    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/api-metrics": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz",
+      "integrity": "sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
-      "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/core": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
-      "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/resources": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
       "dependencies": {
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
-      "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA==",
+    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
       "engines": {
-        "node": ">=14"
+        "node": ">=8.12.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
@@ -11758,7 +11732,8 @@
     "@opentelemetry/context-async-hooks": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.2.0.tgz",
-      "integrity": "sha512-b0ui4aDc5UtU+EWkQlgyxPrTPjird8RhzdyaruoTyiHECWXs9O6qiTv4GLAnBt1XIPK4A/t5aqdW5whDcXDBnA=="
+      "integrity": "sha512-b0ui4aDc5UtU+EWkQlgyxPrTPjird8RhzdyaruoTyiHECWXs9O6qiTv4GLAnBt1XIPK4A/t5aqdW5whDcXDBnA==",
+      "requires": {}
     },
     "@opentelemetry/core": {
       "version": "1.2.0",
@@ -11805,58 +11780,59 @@
       }
     },
     "@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.33.0.tgz",
-      "integrity": "sha512-hGf6WMtJpoepHw4kJ4jYsos/45pq6PNHs3pc1PGm+Vbm7e4m6K1j4ZsRAPsWDw4AbYndFJd+u8YjphcPivhxFw==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.29.2.tgz",
+      "integrity": "sha512-fnKOiOzfahHfyi8OekJm/HRoV9VloJ1VmDoxG5PDxdxbJirkZxokJ+mdE/UZ8Z0PSaL/yqPvBkBnaeFyhoEMng==",
       "requires": {
         "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.33.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.33.0",
-        "@opentelemetry/otlp-transformer": "0.33.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0"
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/otlp-exporter-base": "0.29.2",
+        "@opentelemetry/otlp-proto-exporter-base": "0.29.2",
+        "@opentelemetry/otlp-transformer": "0.29.2",
+        "@opentelemetry/resources": "1.3.1",
+        "@opentelemetry/sdk-trace-base": "1.3.1",
+        "protobufjs": "^6.9.0"
       },
       "dependencies": {
         "@opentelemetry/core": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
-          "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+          "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
           "requires": {
-            "@opentelemetry/semantic-conventions": "1.7.0"
+            "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
         "@opentelemetry/otlp-exporter-base": {
-          "version": "0.33.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.33.0.tgz",
-          "integrity": "sha512-st+nsgv23BXSARFwugy6pheulDfOKjIFvzoYOUzPQDVhQtU8+l7dc50rIEybwXghb13o7mZs6Nb8KOvRk57qww==",
+          "version": "0.29.2",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.29.2.tgz",
+          "integrity": "sha512-tTK+v2ER9Rv7YQXLrCvZpPdNdvZx8TGdZtlK7TKnzpyMRBIf7lqV1Jl0VaHFml+cgVJcGtow/ER6k5uJ5W4kUQ==",
           "requires": {
-            "@opentelemetry/core": "1.7.0"
+            "@opentelemetry/core": "1.3.1"
           }
         },
         "@opentelemetry/resources": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
-          "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+          "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
           "requires": {
-            "@opentelemetry/core": "1.7.0",
-            "@opentelemetry/semantic-conventions": "1.7.0"
+            "@opentelemetry/core": "1.3.1",
+            "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
         "@opentelemetry/sdk-trace-base": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.7.0.tgz",
-          "integrity": "sha512-Iz84C+FVOskmauh9FNnj4+VrA+hG5o+tkMzXuoesvSfunVSioXib0syVFeNXwOm4+M5GdWCuW632LVjqEXStIg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.3.1.tgz",
+          "integrity": "sha512-Or95QZ+9QyvAiwqj+K68z8bDDuyWF50c37w17D10GV1dWzg4Ezcectsu/GB61QcBxm3Y4br0EN5F5TpIFfFliQ==",
           "requires": {
-            "@opentelemetry/core": "1.7.0",
-            "@opentelemetry/resources": "1.7.0",
-            "@opentelemetry/semantic-conventions": "1.7.0"
+            "@opentelemetry/core": "1.3.1",
+            "@opentelemetry/resources": "1.3.1",
+            "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
         "@opentelemetry/semantic-conventions": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
-          "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA=="
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+          "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
         }
       }
     },
@@ -12003,114 +11979,90 @@
       }
     },
     "@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.33.0.tgz",
-      "integrity": "sha512-DFJrqp4VoaFmUbo12Nlw9CxxmqQIa6Aq48OR7Ecv4sh3pf8vgztqak76EPIKlSrw2Fpuo352Dw+Y0nnDyEN15Q==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.29.2.tgz",
+      "integrity": "sha512-a46z6yMUzVKrPMbKZLWyO5z+9x1ja7zyS3dlZ1vQLB9fymdsubZsqpCetyh3uSpmfGtHweTie8z0MgR6MMsmiA==",
       "requires": {
         "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.33.0",
-        "protobufjs": "7.1.1"
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/otlp-exporter-base": "0.29.2",
+        "protobufjs": "^6.9.0"
       },
       "dependencies": {
         "@opentelemetry/core": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
-          "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+          "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
           "requires": {
-            "@opentelemetry/semantic-conventions": "1.7.0"
+            "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
         "@opentelemetry/otlp-exporter-base": {
-          "version": "0.33.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.33.0.tgz",
-          "integrity": "sha512-st+nsgv23BXSARFwugy6pheulDfOKjIFvzoYOUzPQDVhQtU8+l7dc50rIEybwXghb13o7mZs6Nb8KOvRk57qww==",
+          "version": "0.29.2",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.29.2.tgz",
+          "integrity": "sha512-tTK+v2ER9Rv7YQXLrCvZpPdNdvZx8TGdZtlK7TKnzpyMRBIf7lqV1Jl0VaHFml+cgVJcGtow/ER6k5uJ5W4kUQ==",
           "requires": {
-            "@opentelemetry/core": "1.7.0"
+            "@opentelemetry/core": "1.3.1"
           }
         },
         "@opentelemetry/semantic-conventions": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
-          "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA=="
-        },
-        "long": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-          "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
-        },
-        "protobufjs": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
-          "integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+          "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
         }
       }
     },
     "@opentelemetry/otlp-transformer": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.33.0.tgz",
-      "integrity": "sha512-L4OpsUaki9/Fib17t44YkDvAz3RpMZTtl6hYBhcTqAnqY0wVBpQf0ra25GyHQTKj+oiA//ZxvOlmmM/dXCYxoQ==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.29.2.tgz",
+      "integrity": "sha512-Y6dJj+rhRGynxhLlgEJkdkXuLHdFG8igcSBv6oy3m3GHSSvZkyNV34dVjtZJ586mUXsbFuAf6uqjzteobewO1g==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.33.0",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/sdk-metrics": "0.33.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0"
+        "@opentelemetry/api-metrics": "0.29.2",
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/resources": "1.3.1",
+        "@opentelemetry/sdk-metrics-base": "0.29.2",
+        "@opentelemetry/sdk-trace-base": "1.3.1"
       },
       "dependencies": {
         "@opentelemetry/api-metrics": {
-          "version": "0.33.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz",
-          "integrity": "sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==",
+          "version": "0.29.2",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz",
+          "integrity": "sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==",
           "requires": {
             "@opentelemetry/api": "^1.0.0"
           }
         },
         "@opentelemetry/core": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
-          "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+          "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
           "requires": {
-            "@opentelemetry/semantic-conventions": "1.7.0"
+            "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
         "@opentelemetry/resources": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
-          "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+          "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
           "requires": {
-            "@opentelemetry/core": "1.7.0",
-            "@opentelemetry/semantic-conventions": "1.7.0"
+            "@opentelemetry/core": "1.3.1",
+            "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
         "@opentelemetry/sdk-trace-base": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.7.0.tgz",
-          "integrity": "sha512-Iz84C+FVOskmauh9FNnj4+VrA+hG5o+tkMzXuoesvSfunVSioXib0syVFeNXwOm4+M5GdWCuW632LVjqEXStIg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.3.1.tgz",
+          "integrity": "sha512-Or95QZ+9QyvAiwqj+K68z8bDDuyWF50c37w17D10GV1dWzg4Ezcectsu/GB61QcBxm3Y4br0EN5F5TpIFfFliQ==",
           "requires": {
-            "@opentelemetry/core": "1.7.0",
-            "@opentelemetry/resources": "1.7.0",
-            "@opentelemetry/semantic-conventions": "1.7.0"
+            "@opentelemetry/core": "1.3.1",
+            "@opentelemetry/resources": "1.3.1",
+            "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
         "@opentelemetry/semantic-conventions": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
-          "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA=="
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+          "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
         }
       }
     },
@@ -12139,46 +12091,46 @@
         "@opentelemetry/semantic-conventions": "1.2.0"
       }
     },
-    "@opentelemetry/sdk-metrics": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-0.33.0.tgz",
-      "integrity": "sha512-ZXPixOlTd/FHLwpkmm5nTpJE7bZOPfmbSz8hBVFCEHkXE1aKEKaM38UFnZ+2xzOY1tDsDwyxEiiBiDX8y3039A==",
+    "@opentelemetry/sdk-metrics-base": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.29.2.tgz",
+      "integrity": "sha512-7hhhZ/6YRRgAXOUTeCsbe6SIk3wZAdAHnEwGGp7aiVH5AOyioHyHInw4EHtowlD6dbLxUWURjh6k+Geht2zbxg==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.33.0",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/resources": "1.7.0",
+        "@opentelemetry/api-metrics": "0.29.2",
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/resources": "1.3.1",
         "lodash.merge": "4.6.2"
       },
       "dependencies": {
         "@opentelemetry/api-metrics": {
-          "version": "0.33.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz",
-          "integrity": "sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==",
+          "version": "0.29.2",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz",
+          "integrity": "sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==",
           "requires": {
             "@opentelemetry/api": "^1.0.0"
           }
         },
         "@opentelemetry/core": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
-          "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+          "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
           "requires": {
-            "@opentelemetry/semantic-conventions": "1.7.0"
+            "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
         "@opentelemetry/resources": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
-          "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+          "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
           "requires": {
-            "@opentelemetry/core": "1.7.0",
-            "@opentelemetry/semantic-conventions": "1.7.0"
+            "@opentelemetry/core": "1.3.1",
+            "@opentelemetry/semantic-conventions": "1.3.1"
           }
         },
         "@opentelemetry/semantic-conventions": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
-          "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA=="
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+          "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
         }
       }
     },
@@ -12649,7 +12601,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -13914,7 +13867,8 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
       "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-es": {
       "version": "3.0.1",
@@ -13947,7 +13901,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
       "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-node": {
       "version": "11.1.0",
@@ -18560,7 +18515,8 @@
     "ws": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw=="
+      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@opentelemetry/core": "~1.2.0",
         "@opentelemetry/exporter-jaeger": "~1.2.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.28.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.33.0",
         "@opentelemetry/instrumentation": "^0.28.0",
         "@opentelemetry/propagator-b3": "~1.2.0",
         "@opentelemetry/resources": "~1.2.0",
@@ -1624,6 +1625,93 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.33.0.tgz",
+      "integrity": "sha512-hGf6WMtJpoepHw4kJ4jYsos/45pq6PNHs3pc1PGm+Vbm7e4m6K1j4ZsRAPsWDw4AbYndFJd+u8YjphcPivhxFw==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.6.9",
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.33.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.33.0",
+        "@opentelemetry/otlp-transformer": "0.33.0",
+        "@opentelemetry/resources": "1.7.0",
+        "@opentelemetry/sdk-trace-base": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.33.0.tgz",
+      "integrity": "sha512-st+nsgv23BXSARFwugy6pheulDfOKjIFvzoYOUzPQDVhQtU8+l7dc50rIEybwXghb13o7mZs6Nb8KOvRk57qww==",
+      "dependencies": {
+        "@opentelemetry/core": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
+      "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/semantic-conventions": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.7.0.tgz",
+      "integrity": "sha512-Iz84C+FVOskmauh9FNnj4+VrA+hG5o+tkMzXuoesvSfunVSioXib0syVFeNXwOm4+M5GdWCuW632LVjqEXStIg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/resources": "1.7.0",
+        "@opentelemetry/semantic-conventions": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
+      "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.28.0.tgz",
@@ -1819,6 +1907,169 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.33.0.tgz",
+      "integrity": "sha512-DFJrqp4VoaFmUbo12Nlw9CxxmqQIa6Aq48OR7Ecv4sh3pf8vgztqak76EPIKlSrw2Fpuo352Dw+Y0nnDyEN15Q==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.6.9",
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.33.0",
+        "protobufjs": "7.1.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.33.0.tgz",
+      "integrity": "sha512-st+nsgv23BXSARFwugy6pheulDfOKjIFvzoYOUzPQDVhQtU8+l7dc50rIEybwXghb13o7mZs6Nb8KOvRk57qww==",
+      "dependencies": {
+        "@opentelemetry/core": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
+      "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/long": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+    },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/protobufjs": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
+      "integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.33.0.tgz",
+      "integrity": "sha512-L4OpsUaki9/Fib17t44YkDvAz3RpMZTtl6hYBhcTqAnqY0wVBpQf0ra25GyHQTKj+oiA//ZxvOlmmM/dXCYxoQ==",
+      "dependencies": {
+        "@opentelemetry/api-metrics": "0.33.0",
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/resources": "1.7.0",
+        "@opentelemetry/sdk-metrics": "0.33.0",
+        "@opentelemetry/sdk-trace-base": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-metrics": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz",
+      "integrity": "sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
+      "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/semantic-conventions": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.7.0.tgz",
+      "integrity": "sha512-Iz84C+FVOskmauh9FNnj4+VrA+hG5o+tkMzXuoesvSfunVSioXib0syVFeNXwOm4+M5GdWCuW632LVjqEXStIg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/resources": "1.7.0",
+        "@opentelemetry/semantic-conventions": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
+      "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/propagator-b3": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.2.0.tgz",
@@ -1860,6 +2111,71 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-0.33.0.tgz",
+      "integrity": "sha512-ZXPixOlTd/FHLwpkmm5nTpJE7bZOPfmbSz8hBVFCEHkXE1aKEKaM38UFnZ+2xzOY1tDsDwyxEiiBiDX8y3039A==",
+      "dependencies": {
+        "@opentelemetry/api-metrics": "0.33.0",
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/resources": "1.7.0",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/api-metrics": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz",
+      "integrity": "sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
+      "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/semantic-conventions": "1.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
+      "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
@@ -6459,8 +6775,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -11443,8 +11758,7 @@
     "@opentelemetry/context-async-hooks": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.2.0.tgz",
-      "integrity": "sha512-b0ui4aDc5UtU+EWkQlgyxPrTPjird8RhzdyaruoTyiHECWXs9O6qiTv4GLAnBt1XIPK4A/t5aqdW5whDcXDBnA==",
-      "requires": {}
+      "integrity": "sha512-b0ui4aDc5UtU+EWkQlgyxPrTPjird8RhzdyaruoTyiHECWXs9O6qiTv4GLAnBt1XIPK4A/t5aqdW5whDcXDBnA=="
     },
     "@opentelemetry/core": {
       "version": "1.2.0",
@@ -11488,6 +11802,62 @@
         "@opentelemetry/otlp-exporter-base": "0.28.0",
         "@opentelemetry/resources": "1.2.0",
         "@opentelemetry/sdk-trace-base": "1.2.0"
+      }
+    },
+    "@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.33.0.tgz",
+      "integrity": "sha512-hGf6WMtJpoepHw4kJ4jYsos/45pq6PNHs3pc1PGm+Vbm7e4m6K1j4ZsRAPsWDw4AbYndFJd+u8YjphcPivhxFw==",
+      "requires": {
+        "@grpc/proto-loader": "^0.6.9",
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.33.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.33.0",
+        "@opentelemetry/otlp-transformer": "0.33.0",
+        "@opentelemetry/resources": "1.7.0",
+        "@opentelemetry/sdk-trace-base": "1.7.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
+          "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.7.0"
+          }
+        },
+        "@opentelemetry/otlp-exporter-base": {
+          "version": "0.33.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.33.0.tgz",
+          "integrity": "sha512-st+nsgv23BXSARFwugy6pheulDfOKjIFvzoYOUzPQDVhQtU8+l7dc50rIEybwXghb13o7mZs6Nb8KOvRk57qww==",
+          "requires": {
+            "@opentelemetry/core": "1.7.0"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
+          "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+          "requires": {
+            "@opentelemetry/core": "1.7.0",
+            "@opentelemetry/semantic-conventions": "1.7.0"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.7.0.tgz",
+          "integrity": "sha512-Iz84C+FVOskmauh9FNnj4+VrA+hG5o+tkMzXuoesvSfunVSioXib0syVFeNXwOm4+M5GdWCuW632LVjqEXStIg==",
+          "requires": {
+            "@opentelemetry/core": "1.7.0",
+            "@opentelemetry/resources": "1.7.0",
+            "@opentelemetry/semantic-conventions": "1.7.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
+          "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA=="
+        }
       }
     },
     "@opentelemetry/instrumentation": {
@@ -11632,6 +12002,118 @@
         "@opentelemetry/otlp-exporter-base": "0.28.0"
       }
     },
+    "@opentelemetry/otlp-proto-exporter-base": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.33.0.tgz",
+      "integrity": "sha512-DFJrqp4VoaFmUbo12Nlw9CxxmqQIa6Aq48OR7Ecv4sh3pf8vgztqak76EPIKlSrw2Fpuo352Dw+Y0nnDyEN15Q==",
+      "requires": {
+        "@grpc/proto-loader": "^0.6.9",
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/otlp-exporter-base": "0.33.0",
+        "protobufjs": "7.1.1"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
+          "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.7.0"
+          }
+        },
+        "@opentelemetry/otlp-exporter-base": {
+          "version": "0.33.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.33.0.tgz",
+          "integrity": "sha512-st+nsgv23BXSARFwugy6pheulDfOKjIFvzoYOUzPQDVhQtU8+l7dc50rIEybwXghb13o7mZs6Nb8KOvRk57qww==",
+          "requires": {
+            "@opentelemetry/core": "1.7.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
+          "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA=="
+        },
+        "long": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+          "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+        },
+        "protobufjs": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
+          "integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          }
+        }
+      }
+    },
+    "@opentelemetry/otlp-transformer": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.33.0.tgz",
+      "integrity": "sha512-L4OpsUaki9/Fib17t44YkDvAz3RpMZTtl6hYBhcTqAnqY0wVBpQf0ra25GyHQTKj+oiA//ZxvOlmmM/dXCYxoQ==",
+      "requires": {
+        "@opentelemetry/api-metrics": "0.33.0",
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/resources": "1.7.0",
+        "@opentelemetry/sdk-metrics": "0.33.0",
+        "@opentelemetry/sdk-trace-base": "1.7.0"
+      },
+      "dependencies": {
+        "@opentelemetry/api-metrics": {
+          "version": "0.33.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz",
+          "integrity": "sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==",
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
+        },
+        "@opentelemetry/core": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
+          "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.7.0"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
+          "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+          "requires": {
+            "@opentelemetry/core": "1.7.0",
+            "@opentelemetry/semantic-conventions": "1.7.0"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.7.0.tgz",
+          "integrity": "sha512-Iz84C+FVOskmauh9FNnj4+VrA+hG5o+tkMzXuoesvSfunVSioXib0syVFeNXwOm4+M5GdWCuW632LVjqEXStIg==",
+          "requires": {
+            "@opentelemetry/core": "1.7.0",
+            "@opentelemetry/resources": "1.7.0",
+            "@opentelemetry/semantic-conventions": "1.7.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
+          "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA=="
+        }
+      }
+    },
     "@opentelemetry/propagator-b3": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.2.0.tgz",
@@ -11655,6 +12137,49 @@
       "requires": {
         "@opentelemetry/core": "1.2.0",
         "@opentelemetry/semantic-conventions": "1.2.0"
+      }
+    },
+    "@opentelemetry/sdk-metrics": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-0.33.0.tgz",
+      "integrity": "sha512-ZXPixOlTd/FHLwpkmm5nTpJE7bZOPfmbSz8hBVFCEHkXE1aKEKaM38UFnZ+2xzOY1tDsDwyxEiiBiDX8y3039A==",
+      "requires": {
+        "@opentelemetry/api-metrics": "0.33.0",
+        "@opentelemetry/core": "1.7.0",
+        "@opentelemetry/resources": "1.7.0",
+        "lodash.merge": "4.6.2"
+      },
+      "dependencies": {
+        "@opentelemetry/api-metrics": {
+          "version": "0.33.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz",
+          "integrity": "sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==",
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
+        },
+        "@opentelemetry/core": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
+          "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.7.0"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
+          "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+          "requires": {
+            "@opentelemetry/core": "1.7.0",
+            "@opentelemetry/semantic-conventions": "1.7.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
+          "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA=="
+        }
       }
     },
     "@opentelemetry/sdk-trace-base": {
@@ -12124,8 +12649,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -13390,8 +13914,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
       "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-es": {
       "version": "3.0.1",
@@ -13424,8 +13947,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
       "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-node": {
       "version": "11.1.0",
@@ -15137,8 +15659,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -18039,8 +18560,7 @@
     "ws": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
-      "requires": {}
+      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@opentelemetry/core": "~1.2.0",
     "@opentelemetry/exporter-jaeger": "~1.2.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.28.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.33.0",
     "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/propagator-b3": "~1.2.0",
     "@opentelemetry/resources": "~1.2.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@opentelemetry/core": "~1.2.0",
     "@opentelemetry/exporter-jaeger": "~1.2.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.28.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.33.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.29.2",
     "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/propagator-b3": "~1.2.0",
     "@opentelemetry/resources": "~1.2.0",

--- a/src/tracing/options.ts
+++ b/src/tracing/options.ts
@@ -274,7 +274,7 @@ function resolveExporterType(options: Partial<Options>): ExporterType {
     if (tracesExporter) {
       if (!isSupportedRealmExporter(tracesExporter)) {
         throw new Error(
-          'Setting the Splunk realm with an explicit OTEL_TRACES_EXPORTER requires OTEL_TRACES_EXPORTER to be jaeger-thrift-splunk'
+          'Setting the Splunk realm with an explicit OTEL_TRACES_EXPORTER requires OTEL_TRACES_EXPORTER to be either jaeger-thrift-splunk or otlp-splunk'
         );
       }
     } else {

--- a/src/tracing/options.ts
+++ b/src/tracing/options.ts
@@ -43,7 +43,11 @@ import { Resource } from '@opentelemetry/resources';
 
 const JaegerExporter = util.deprecate(
   OriginalJaegerExporter,
-  'Jaeger exporter is deprecated and will be removed in 2.x'
+  [
+    '"jaeger-thrift-splunk" trace exporter is deprecated and may be removed in a future major release. Use the default',
+    'OTLP exporter instead, or set the SPLUNK_REALM and SPLUNK_ACCESS_TOKEN environment variables to send',
+    'telemetry directly to Splunk Observability Cloud.',
+  ].join(' ')
 );
 
 type SpanExporterFactory = (options: Options) => SpanExporter;

--- a/src/tracing/options.ts
+++ b/src/tracing/options.ts
@@ -27,7 +27,7 @@ import { getInstrumentations } from '../instrumentations';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 // eslint-disable-next-line node/no-extraneous-import
 import { Metadata } from '@grpc/grpc-js';
-import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
+import { JaegerExporter as OriginalJaegerExporter } from '@opentelemetry/exporter-jaeger';
 import { detect as detectResource } from '../resource';
 import { deduplicate, defaultServiceName, getEnvBoolean } from '../utils';
 import { NodeTracerConfig } from '@opentelemetry/sdk-trace-node';
@@ -40,6 +40,11 @@ import {
 } from '@opentelemetry/core';
 import { SplunkBatchSpanProcessor } from './SplunkBatchSpanProcessor';
 import { Resource } from '@opentelemetry/resources';
+
+const JaegerExporter = util.deprecate(
+  OriginalJaegerExporter,
+  'Jaeger exporter is deprecated and will be removed in 2.x'
+);
 
 type SpanExporterFactory = (options: Options) => SpanExporter;
 

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -38,6 +38,7 @@ import {
   jaegerSpanExporterFactory,
   otlpSpanExporterFactory,
   splunkSpanExporterFactory,
+  splunkOtlpSpanExporterFactory,
   defaultSpanProcessorFactory,
   Options,
 } from '../src/tracing/options';
@@ -277,6 +278,20 @@ describe('options', () => {
       assert.deepStrictEqual(
         options.spanExporterFactory,
         splunkSpanExporterFactory
+      );
+    });
+
+    it('will let exporter factory compile the endpoint if realm is set', () => {
+      process.env.SPLUNK_REALM = 'us0';
+      process.env.SPLUNK_ACCESS_TOKEN = 'abc';
+      process.env.OTEL_TRACES_EXPORTER = 'otlp-splunk';
+
+      const options = _setDefaultOptions();
+      // let's exporter factory set the endpoint
+      assert.deepStrictEqual(options.endpoint, undefined);
+      assert.deepStrictEqual(
+        options.spanExporterFactory,
+        splunkOtlpSpanExporterFactory
       );
     });
 


### PR DESCRIPTION
Continuation of https://github.com/signalfx/splunk-otel-js/pull/560

Additional changes:
* Use a version of `@opentelemetry/exporter-trace-otlp-proto` that is compatible with Node.js 12.x