### PR TITLE
fix: remove instrumentations from common config

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -125,7 +125,6 @@ const { start } = require('@splunk/otel');
 start({
   // accessToken,
   // endpoint,
-  // instrumentations,
   // serviceName,
   tracing: {
     // tracing-specific options here.

--- a/src/start.ts
+++ b/src/start.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { InstrumentationOption } from '@opentelemetry/instrumentation';
-
 import { assertNoExtraneousProperties, parseEnvBooleanString } from './utils';
 import { startMetrics, MetricsOptions } from './metrics';
 import { startProfiling, ProfilingOptions } from './profiling';

--- a/src/start.ts
+++ b/src/start.ts
@@ -24,7 +24,6 @@ interface Options {
   accessToken: string;
   endpoint: string;
   serviceName: string;
-  instrumentations: InstrumentationOption[];
   // Signal-specific configuration options:
   metrics: boolean | MetricsOptions;
   profiling: boolean | ProfilingOptions;
@@ -60,7 +59,6 @@ export const start = (options: Partial<Options> = {}) => {
   assertNoExtraneousProperties(restOptions, [
     'accessToken',
     'endpoint',
-    'instrumentations',
     'serviceName',
   ]);
 


### PR DESCRIPTION
`instrumentations` should only be part of `tracing` configuration.