### PR TITLE
fix: allow partial signal options being passed to start

### DIFF
--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -38,7 +38,7 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 export type MetricReaderFactory = (options: MetricsOptions) => MetricReader[];
 export type ResourceFactory = (resource: Resource) => Resource;
 
-export interface MetricsOptions {
+interface MetricsOptions {
   accessToken: string;
   realm?: string;
   serviceName: string;

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -30,6 +30,7 @@ import {
   ProfilingExporter,
   ProfilingExtension,
   ProfilingOptions,
+  StartProfilingOptions,
   ProfilingStartOptions,
   allowedProfilingOptions,
 } from './types';
@@ -38,7 +39,7 @@ import { OTLPProfilingExporter } from './OTLPProfilingExporter';
 import { DebugExporter } from './DebugExporter';
 import { isTracingContextManagerEnabled } from '../tracing';
 
-export { ProfilingOptions };
+export { StartProfilingOptions };
 
 /* The following are wrappers around native functions to give more context to profiling samples. */
 function extStopProfiling(extension: ProfilingExtension) {
@@ -100,7 +101,7 @@ export function isProfilingContextManagerSet(): boolean {
   return profilingContextManagerEnabled;
 }
 
-export function startProfiling(opts: Partial<ProfilingOptions> = {}) {
+export function startProfiling(opts: StartProfilingOptions = {}) {
   assertNoExtraneousProperties(opts, allowedProfilingOptions);
 
   const options = _setDefaultOptions(opts);

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -88,7 +88,7 @@ export interface MemoryProfilingOptions {
   sampleIntervalBytes?: number;
 }
 
-interface ProfilingOptions {
+export interface ProfilingOptions {
   endpoint: string;
   serviceName: string;
   // Profiling-specific configuration options:

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -88,7 +88,7 @@ export interface MemoryProfilingOptions {
   sampleIntervalBytes?: number;
 }
 
-export interface ProfilingOptions {
+interface ProfilingOptions {
   endpoint: string;
   serviceName: string;
   // Profiling-specific configuration options:
@@ -100,6 +100,8 @@ export interface ProfilingOptions {
   memoryProfilingEnabled: boolean;
   memoryProfilingOptions?: MemoryProfilingOptions;
 }
+
+export type StartProfilingOptions = Partial<ProfilingOptions>;
 
 export interface ProfilingExporter {
   send(profile: RawProfilingData): void;

--- a/src/start.ts
+++ b/src/start.ts
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 import { assertNoExtraneousProperties, parseEnvBooleanString } from './utils';
-import { startMetrics, MetricsOptions } from './metrics';
-import { startProfiling, ProfilingOptions } from './profiling';
-import { startTracing, stopTracing, TracingOptions } from './tracing';
+import { startMetrics, StartMetricsOptions } from './metrics';
+import { startProfiling, StartProfilingOptions } from './profiling';
+import { startTracing, stopTracing, StartTracingOptions } from './tracing';
 
 interface Options {
   accessToken: string;
   endpoint: string;
   serviceName: string;
   // Signal-specific configuration options:
-  metrics: boolean | MetricsOptions;
-  profiling: boolean | ProfilingOptions;
-  tracing: boolean | TracingOptions;
+  metrics: boolean | StartMetricsOptions;
+  profiling: boolean | StartProfilingOptions;
+  tracing: boolean | StartTracingOptions;
 }
 
 interface RunningState {

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -59,8 +59,8 @@ export function isTracingContextManagerEnabled(): boolean {
   return tracingContextManagerEnabled;
 }
 
-export { Options as TracingOptions };
-export function startTracing(opts: Partial<Options> = {}): boolean {
+export type StartTracingOptions = Partial<Options>;
+export function startTracing(opts: StartTracingOptions = {}): boolean {
   assert(!isStarted, 'Splunk APM already started');
   isStarted = true;
 

--- a/test/start.test.ts
+++ b/test/start.test.ts
@@ -165,6 +165,17 @@ describe('start', () => {
   });
 
   describe('configuration', () => {
+    it('works with partial configurations', () => {
+      start({
+        ...CONFIG.general,
+        profiling: {},
+        tracing: {},
+        metrics: {},
+      });
+
+      assertCalled(signals.start, ['tracing', 'profiling', 'metrics']);
+    });
+
     it('works if all the configuration options are passed', () => {
       start({
         ...CONFIG.general,
@@ -185,7 +196,7 @@ describe('start', () => {
       assertCalled(signals.start, ['tracing', 'profiling', 'metrics']);
     });
 
-    it('works if all the configuration options are passed', () => {
+    it('throws if invalid configuration options are passed', () => {
       assert.throws(
         () =>
           start({


### PR DESCRIPTION
When signal-specific options were given for `start`, the types required all of the fields to be set, but `start{Tracing,Metrics,Profiling}` were using `Partial<Options>` types.