### PR TITLE
feat: enable runtime metrics by default and for memory profiling

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -100,7 +100,7 @@ Configuration examples can be seen [here](metrics.md).
 | `OTEL_RESOURCE_ATTRIBUTES`                                      |                         | Stable  | The resource attributes to metric data. <details><summary>Environment variable example</summary>`key1=val1,key2=val2`</details>
 | `SPLUNK_METRICS_ENABLED`<br>n/a (enabled by calling `start`) | `false`             | Experimental | Sets up the metrics pipeline (global meter provider, exporters).
 | n/a<br>`metrics.resourceFactory`                                |                         | Experimental | Callback which allows to filter the default resource or provide a custom one. The function takes one argument of type `Resource` which is the resource pre-filled by the SDK containing the `service.name`, environment, host and process attributes. |
-| `SPLUNK_RUNTIME_METRICS_ENABLED`<br>`metrics.runtimeMetricsEnabled` | `false`                 | Experimental | Enable collecting and exporting of runtime metrics. See [metrics documentation](metrics.md) for more information.
+| `SPLUNK_RUNTIME_METRICS_ENABLED`<br>`metrics.runtimeMetricsEnabled` | `true`                 | Experimental | Enable collecting and exporting of runtime metrics. See [metrics documentation](metrics.md) for more information.
 | `SPLUNK_RUNTIME_METRICS_COLLECTION_INTERVAL`<br>`metrics.runtimeMetricsCollectionIntervalMillis`  | `5000`                 | Experimental | The interval, in milliseconds, during which GC and event loop statistics are collected. After the collection is done, the values become available to the metric exporter.
 
 ### Profiling

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -135,20 +135,7 @@ counter.add(99);
 
 ## Runtime metrics
 
-Runtime metrics are disabled by default and need to be explicitly enabled ([advanced configuration](advanced-config.md#metrics)):
-
-```javascript
-const { start } = require('@splunk/otel');
-
-start({
-  serviceName: 'my-service',
-  metrics: {
-    runtimeMetricsEnabled: true,
-  },
-});
-```
-
-The following is a list of metrics automatically collected and exported:
+The following is a list of metrics automatically collected and exported if runtime metrics is switched on:
 
 - `process.runtime.nodejs.memory.heap.total` (gauge, bytes) - Heap total via `process.memoryUsage().heapTotal`.
 - `process.runtime.nodejs.memory.heap.used` (gauge, bytes) - Heap used via `process.memoryUsage().heapUsed`.
@@ -158,3 +145,17 @@ The following is a list of metrics automatically collected and exported:
 - `process.runtime.nodejs.memory.gc.count` (counter, count) - Number of times GC ran.
 - `process.runtime.nodejs.event_loop.lag.max` (gauge, nanoseconds) - Max event loop lag within the collection interval.
 - `process.runtime.nodejs.event_loop.lag.min` (gauge, nanoseconds) - Min event loop lag within the collection interval.
+
+Runtime metrics are enabled by default if metrics are enabled. To switch them off, set `runtimeMetricsEnabled` to `false`:
+
+```javascript
+const { start } = require('@splunk/otel');
+
+start({
+  serviceName: 'my-service',
+  metrics: {
+    runtimeMetricsEnabled: false,
+  },
+});
+```
+

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -26,6 +26,9 @@ if (getEnvBoolean('SPLUNK_PROFILER_ENABLED', false)) {
 
 startTracing();
 
-if (getEnvBoolean('SPLUNK_METRICS_ENABLED', false)) {
+if (
+  getEnvBoolean('SPLUNK_METRICS_ENABLED', false) ||
+  getEnvBoolean('SPLUNK_PROFILER_MEMORY_ENABLED', false)
+) {
   startMetrics();
 }

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -363,7 +363,7 @@ export function _setDefaultOptions(
       getEnvNumber('OTEL_METRIC_EXPORT_INTERVAL', 30_000),
     runtimeMetricsEnabled:
       options.runtimeMetricsEnabled ??
-      getEnvBoolean('SPLUNK_RUNTIME_METRICS_ENABLED', false),
+      getEnvBoolean('SPLUNK_RUNTIME_METRICS_ENABLED', true),
     runtimeMetricsCollectionIntervalMillis:
       options.runtimeMetricsCollectionIntervalMillis ||
       getEnvNumber('SPLUNK_RUNTIME_METRICS_COLLECTION_INTERVAL', 5000),

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -128,7 +128,7 @@ describe('metrics', () => {
         options.resource.attributes[SemanticResourceAttributes.SERVICE_NAME],
         'unnamed-node-service'
       );
-      assert.deepEqual(options.runtimeMetricsEnabled, false);
+      assert.deepEqual(options.runtimeMetricsEnabled, true);
       assert.deepEqual(options.runtimeMetricsCollectionIntervalMillis, 5000);
       assert(
         options.metricReaderFactory(options)[0]['_exporter'] instanceof

--- a/test/start.test.ts
+++ b/test/start.test.ts
@@ -20,6 +20,7 @@ import * as metrics from '../src/metrics';
 import * as profiling from '../src/profiling';
 import * as tracing from '../src/tracing';
 import { start, stop } from '../src';
+import { Resource } from '@opentelemetry/resources';
 
 import * as utils from './utils';
 
@@ -42,7 +43,7 @@ CONFIG.metrics = {
 const callstackInterval = 'callstackInterval';
 const collectionDuration = 'collectionDuration';
 const debugExport = 'debugExport';
-const resource = 'resource';
+const resource = Resource.empty();
 CONFIG.profiling = {
   callstackInterval,
   collectionDuration,


### PR DESCRIPTION
* Enable runtime metrics by default if metrics are enabled
* Enable metrics if memory profiling is enabled