### PR TITLE
chore: remove usage of changelog.json from releaser script

### DIFF
--- a/scripts/release-message.js
+++ b/scripts/release-message.js
@@ -1,18 +1,7 @@
-const changelog = require('../CHANGELOG.json');
 const { version } = require('../package.json');
 const { dependencies } = require('../package-lock.json');
 
 exports.getReleaseMessage = () => {
-  const release = changelog.entries.find(entry => entry.version == version);
-  if (!release) {
-    throw new Error('Current version not found in CHANGELOG.json');
-  }
-
-  const commentTypes = Object.keys(release.comments);
-  const changes = commentTypes.flatMap(type => {
-    return release.comments[type].map(change => `* (${type}) ${change.comment} by ${change.author}`);
-  });
-
   const otelApiVersion = dependencies['@opentelemetry/api'].version;
   const otelCoreVersion = dependencies['@opentelemetry/core'].version;
   const otelInstrumentationVersion = dependencies['@opentelemetry/instrumentation-http'].version;
@@ -24,6 +13,5 @@ exports.getReleaseMessage = () => {
     '',
     '## Changes',
     '',
-    changes.join('\n'),
   ].join('\n');
 };


### PR DESCRIPTION
Going to get rid of beachball / CHANGELOG.json after this, can't write detailed changelogs with it anyway.