### PR TITLE
feat: add support for OTEL_EXPORTER_OTLP_PROTOCOL, OTEL_EXPORTER_OTLP_ENDPOINT

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -62,7 +62,7 @@ This distribution supports all the configuration options supported by the compon
 | `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`                        |                         | Stable  | Maximum allowed attribute value size. Empty value is treated as infinity
 | `OTEL_SPAN_EVENT_COUNT_LIMIT`                                   | `128`                   | Stable  | 
 | `OTEL_SPAN_LINK_COUNT_LIMIT`                                    | `1000`\*                | Stable  | 
-| `OTEL_TRACES_EXPORTER`<br>`traces.tracesExporter`               | `otlp`                  | Stable  | Chooses the trace exporters. Shortcut for setting `spanExporterFactory`. Comma-delimited list of exporters. Currently supported values: `otlp`, `console`.
+| `OTEL_TRACES_EXPORTER`<br>`tracing.spanExporterFactory`         | `otlp`                  | Stable  | Chooses the trace exporters. Shortcut for setting `spanExporterFactory`. Comma-delimited list of exporters. Currently supported values: `otlp`, `console`.
 | `OTEL_TRACES_SAMPLER`                                           | `parentbased_always_on` | Stable  | Sampler to be used for traces. See [Sampling](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampling)
 | `OTEL_TRACES_SAMPLER_ARG`                                       |                         | Stable  | String value to be used as the sampler argument. Only be used if OTEL_TRACES_SAMPLER is set.
 | `SPLUNK_ACCESS_TOKEN`<br>`accessToken`                          |                         | Stable  | The optional access token for exporting signal data directly to SignalFx API.

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -62,7 +62,7 @@ This distribution supports all the configuration options supported by the compon
 | `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`                        |                         | Stable  | Maximum allowed attribute value size. Empty value is treated as infinity
 | `OTEL_SPAN_EVENT_COUNT_LIMIT`                                   | `128`                   | Stable  | 
 | `OTEL_SPAN_LINK_COUNT_LIMIT`                                    | `1000`\*                | Stable  | 
-| `OTEL_TRACES_EXPORTER`<br>`traces.tracesExporter`               | `otlp`                  | Stable  | Chooses the exporter. Shortcut for setting `spanExporterFactory`. One of [`otlp`, `otlp-splunk`, `console-splunk`]. See [`SpanExporterMap`](../src/tracing/options.ts).
+| `OTEL_TRACES_EXPORTER`<br>`traces.tracesExporter`               | `otlp`                  | Stable  | Chooses the trace exporters. Shortcut for setting `spanExporterFactory`. Comma-delimited list of exporters. Currently supported values: `otlp`, `console`.
 | `OTEL_TRACES_SAMPLER`                                           | `parentbased_always_on` | Stable  | Sampler to be used for traces. See [Sampling](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampling)
 | `OTEL_TRACES_SAMPLER_ARG`                                       |                         | Stable  | String value to be used as the sampler argument. Only be used if OTEL_TRACES_SAMPLER is set.
 | `SPLUNK_ACCESS_TOKEN`<br>`accessToken`                          |                         | Stable  | The optional access token for exporting signal data directly to SignalFx API.

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -26,7 +26,6 @@ docker logs otel-collector -f 2>&1 | grep hello
 It's also possible to send the traces directly to Splunk APM. For that additional environment variables need to be set up:
 
 ```shell
-export OTEL_TRACES_EXPORTER="otlp-splunk"
 export SPLUNK_REALM="<your Splunk realm>"
 export SPLUNK_ACCESS_TOKEN="<your access token>"
 # Optional. To set the environment:

--- a/examples/express/.env.otlp-splunk
+++ b/examples/express/.env.otlp-splunk
@@ -2,5 +2,4 @@ OTEL_SERVICE_NAME='collectorless-express-example'
 OTEL_RESOURCE_ATTRIBUTES='deployment.environment=dev'
 
 SPLUNK_ACCESS_TOKEN='0123456789abcdefghijkl'
-OTEL_TRACES_EXPORTER='otlp-splunk'
 SPLUNK_REALM='us1'

--- a/examples/mixed/README.md
+++ b/examples/mixed/README.md
@@ -38,7 +38,6 @@ and the application logs to stdout:
 It's also possible to send the traces directly to Splunk APM. For that additional environment variables need to be set up:
 
 ```shell
-export OTEL_TRACES_EXPORTER="otlp-splunk"
 # Replace <realm> with the correct realm:
 export SPLUNK_REALM="<your Splunk APM realm>"
 export SPLUNK_ACCESS_TOKEN="<your access token>"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-// TODO: use assert.strict once we deprecate node@8
-import * as assert from 'assert';
+import { strict as assert } from 'assert';
 
 export const defaultServiceName = 'unnamed-node-service';
 
@@ -69,6 +68,31 @@ export function getEnvNumber(key: string, defaultValue: number): number {
 
 export function deduplicate(arr: string[]) {
   return [...new Set(arr)];
+}
+
+export function getEnvArray(key: string, defaultValue: string[]): string[] {
+  const value = process.env[key];
+
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  return deduplicate(value.split(',')).map((v) => v.trim());
+}
+
+export function getEnvValueByPrecedence(
+  keys: string[],
+  defaultValue?: string
+): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key];
+
+    if (value !== undefined) {
+      return value;
+    }
+  }
+
+  return defaultValue;
 }
 
 const formatStringSet = (set: Set<string> | string[]) => {

--- a/test/instrumentation/redis.test.ts
+++ b/test/instrumentation/redis.test.ts
@@ -65,7 +65,7 @@ describe('Redis instrumentation', () => {
     instrumentations: [new RedisInstrumentation()],
     spanExporterFactory: () => exporter,
     spanProcessorFactory: (options) => {
-      return (spanProcessor = defaultSpanProcessorFactory(options));
+      return ([spanProcessor] = defaultSpanProcessorFactory(options));
     },
   });
 

--- a/test/propagation.test.ts
+++ b/test/propagation.test.ts
@@ -155,7 +155,7 @@ describe('propagation', () => {
     startTracing({
       spanExporterFactory: () => exporter,
       spanProcessorFactory: (options) => {
-        return (spanProcessor = defaultSpanProcessorFactory(options));
+        return ([spanProcessor] = defaultSpanProcessorFactory(options));
       },
     });
 

--- a/test/tracing/tracing.test.ts
+++ b/test/tracing/tracing.test.ts
@@ -102,7 +102,23 @@ describe('tracing:otlp', () => {
     stopTracing();
   });
 
-  it('setups tracing with multiple processors', () => {
+  it('sets up tracing with a single processor', () => {
+    startTracing({
+      spanProcessorFactory: () => {
+        return new SimpleSpanProcessor(new ConsoleSpanExporter());
+      },
+    });
+
+    sinon.assert.calledOnce(addSpanProcessorMock);
+    const p1 = addSpanProcessorMock.getCall(0).args[0];
+
+    assert(p1 instanceof SimpleSpanProcessor);
+    const exp1 = p1['_exporter'];
+    assert(exp1 instanceof ConsoleSpanExporter);
+    stopTracing();
+  });
+
+  it('sets up tracing with multiple processors', () => {
     startTracing({
       spanProcessorFactory: function (options) {
         return [

--- a/test/uri_parameter_capture.test.ts
+++ b/test/uri_parameter_capture.test.ts
@@ -65,7 +65,7 @@ describe('Capturing URI parameters', () => {
   const testOpts = () => ({
     spanExporterFactory: () => exporter,
     spanProcessorFactory: (options) => {
-      return (spanProcessor = defaultSpanProcessorFactory(options));
+      return ([spanProcessor] = defaultSpanProcessorFactory(options));
     },
   });
 


### PR DESCRIPTION
* Drop dubious possible values for `OTEL_TRACES_EXPORTER`, e.g. `otlp-splunk` which meant the HTTP protobuf exporter.
* Switching between gRPC and HTTP is now done via `OTEL_EXPORTER_OTLP_PROTOCOL` and `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` with the latter taking precedence as per OTel spec.
* Add support for `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. Order of precedence: programmatically -> `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` -> `OTEL_EXPORTER_OTLP_ENDPOINT`.
* It is now possible to specify multiple exporters, separated by commas to `OTEL_TRACES_EXPORTER`. The only accepted values for now are `otlp` and `console`.