### PR TITLE
feat: remove command line values from process detector

### DIFF
--- a/src/detectors/ProcessDetector.ts
+++ b/src/detectors/ProcessDetector.ts
@@ -56,13 +56,9 @@ class ProcessDetector {
     const processResource: ResourceAttributes = {
       [SemanticResourceAttributes.PROCESS_PID]: process.pid,
       [SemanticResourceAttributes.PROCESS_EXECUTABLE_NAME]: process.title || '',
-      [SemanticResourceAttributes.PROCESS_COMMAND]: process.argv[1] || '',
-      [SemanticResourceAttributes.PROCESS_COMMAND_LINE]:
-        process.argv.join(' ') || '',
       [SemanticResourceAttributes.PROCESS_RUNTIME_VERSION]:
         process.versions.node,
       [SemanticResourceAttributes.PROCESS_RUNTIME_NAME]: 'nodejs',
-      [SemanticResourceAttributes.PROCESS_RUNTIME_DESCRIPTION]: 'Node.js',
     };
     return this._getResourceAttributes(processResource, config);
   }
@@ -82,8 +78,6 @@ class ProcessDetector {
         '' ||
       processResource[SemanticResourceAttributes.PROCESS_EXECUTABLE_PATH] ===
         '' ||
-      processResource[SemanticResourceAttributes.PROCESS_COMMAND] === '' ||
-      processResource[SemanticResourceAttributes.PROCESS_COMMAND_LINE] === '' ||
       processResource[SemanticResourceAttributes.PROCESS_RUNTIME_VERSION] === ''
     ) {
       diag.debug(

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -69,23 +69,6 @@ const MATCH_SERVICE_NAME_WARNING = sinon.match(/service\.name.*not.*set/i);
 const MATCH_NO_INSTRUMENTATIONS_WARNING = sinon.match(
   /no.*instrumentation.*install.*package/i
 );
-// List of resource attributes we expect to see detected
-const expectedAttributes = new Set([
-  SemanticResourceAttributes.CONTAINER_ID,
-  SemanticResourceAttributes.HOST_ARCH,
-  SemanticResourceAttributes.HOST_NAME,
-  SemanticResourceAttributes.OS_TYPE,
-  SemanticResourceAttributes.OS_VERSION,
-  SemanticResourceAttributes.PROCESS_COMMAND,
-  SemanticResourceAttributes.PROCESS_COMMAND_LINE,
-  SemanticResourceAttributes.PROCESS_EXECUTABLE_NAME,
-  SemanticResourceAttributes.PROCESS_EXECUTABLE_PATH,
-  SemanticResourceAttributes.PROCESS_PID,
-  SemanticResourceAttributes.PROCESS_RUNTIME_DESCRIPTION,
-  SemanticResourceAttributes.PROCESS_RUNTIME_NAME,
-  SemanticResourceAttributes.PROCESS_RUNTIME_VERSION,
-  'splunk.distro.version',
-]);
 
 describe('options', () => {
   let logger;
@@ -144,13 +127,32 @@ describe('options', () => {
         ]
       );
 
+      const expectedAttributes = new Set([
+        SemanticResourceAttributes.CONTAINER_ID,
+        SemanticResourceAttributes.HOST_ARCH,
+        SemanticResourceAttributes.HOST_NAME,
+        SemanticResourceAttributes.OS_TYPE,
+        SemanticResourceAttributes.OS_VERSION,
+        SemanticResourceAttributes.PROCESS_EXECUTABLE_NAME,
+        SemanticResourceAttributes.PROCESS_PID,
+        SemanticResourceAttributes.PROCESS_RUNTIME_NAME,
+        SemanticResourceAttributes.PROCESS_RUNTIME_VERSION,
+        'splunk.distro.version',
+      ]);
+
+      expectedAttributes.forEach((processAttribute) => {
+        assert(
+          options.tracerConfig.resource.attributes[processAttribute],
+          `${processAttribute} missing`
+        );
+      });
+
       // resource attributes for process, host and os are different at each run, iterate through them, make sure they exist and then delete
       Object.keys(options.tracerConfig.resource.attributes)
         .filter((attribute) => {
           return expectedAttributes.has(attribute);
         })
         .forEach((processAttribute) => {
-          assert(options.tracerConfig.resource.attributes[processAttribute]);
           delete options.tracerConfig.resource.attributes[processAttribute];
         });
 

--- a/test/resource.test.ts
+++ b/test/resource.test.ts
@@ -143,8 +143,6 @@ describe('resource detector', () => {
 
       for (const attributeName of [
         'process.executable.name',
-        'process.command',
-        'process.command_line',
         'process.runtime.version',
         'process.runtime.name',
       ]) {


### PR DESCRIPTION
* Command line values are removed from resource detector due to ingest limitations.
* Removed runtime description as it provides no information about Node.js and is not [required by the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/process.md#javascript-runtimes)