### PR TITLE
fix: don't create metrics endpoint too early

### DIFF
--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -392,10 +392,6 @@ export function _setDefaultOptions(
         'Splunk realm is set with a custom metric reader. Make sure to use OTLP metrics proto HTTP exporter.'
       );
     }
-
-    if (!endpoint) {
-      endpoint = `https://ingest.${realm}.signalfx.com/v2/datapoint/otlp`;
-    }
   }
 
   let defaultResource = detectResource();

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -376,7 +376,7 @@ export function _setDefaultOptions(
   const accessToken =
     options.accessToken || process.env.SPLUNK_ACCESS_TOKEN || '';
 
-  let endpoint = options.endpoint || process.env.SPLUNK_METRICS_ENDPOINT;
+  const endpoint = options.endpoint || process.env.SPLUNK_METRICS_ENDPOINT;
 
   const realm = options.realm || process.env.SPLUNK_REALM || '';
 

--- a/test/metrics.options.test.ts
+++ b/test/metrics.options.test.ts
@@ -139,15 +139,20 @@ describe('metrics options', () => {
     it('chooses the correct endpoint when realm is set', () => {
       process.env.SPLUNK_REALM = 'eu0';
       process.env.SPLUNK_ACCESS_TOKEN = 'abc';
+
       const options = _setDefaultOptions();
+      const [reader] = options.metricReaderFactory(options);
+      const exporter = reader['_exporter'];
+      assert(exporter instanceof OTLPHttpProtoMetricExporter);
+
       assert.deepStrictEqual(
-        options.endpoint,
-        'https://ingest.eu0.signalfx.com/v2/datapoint/otlp'
+        exporter['_otlpExporter'].headers['X-SF-TOKEN'],
+        'abc'
       );
-      assert(
-        options.metricReaderFactory(options)[0]['_exporter'] instanceof
-          OTLPHttpProtoMetricExporter,
-        'Expected the metric exporter to be OTLP HTTP proto exporter when realm is set'
+
+      assert.deepStrictEqual(
+        exporter['_otlpExporter'].url,
+        'https://ingest.eu0.signalfx.com/v2/datapoint/otlp'
       );
     });
 


### PR DESCRIPTION
The endpoint is overwritten in the OTLP exporter factory anyway