### PR TITLE
feat: read service name from package.json

### DIFF
--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -399,7 +399,7 @@ export function _setDefaultOptions(
   const serviceName = String(
     options.serviceName ||
       defaultResource.attributes[SemanticResourceAttributes.SERVICE_NAME] ||
-      defaultServiceName
+      defaultServiceName()
   );
 
   defaultResource = defaultResource.merge(

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -206,7 +206,7 @@ export function _setDefaultOptions(
     options.serviceName ||
       process.env.OTEL_SERVICE_NAME ||
       combinedResource.attributes[SemanticResourceAttributes.SERVICE_NAME] ||
-      defaultServiceName
+      defaultServiceName()
   );
 
   let resource =
@@ -216,8 +216,7 @@ export function _setDefaultOptions(
 
   resource = resource.merge(
     new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]:
-        serviceName || defaultServiceName,
+      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
     })
   );
 

--- a/src/tracing/options.ts
+++ b/src/tracing/options.ts
@@ -133,7 +133,7 @@ export function _setDefaultOptions(options: Partial<Options> = {}): Options {
   resource = resource.merge(
     new Resource({
       [SemanticResourceAttributes.SERVICE_NAME]:
-        serviceName || defaultServiceName,
+        serviceName || defaultServiceName(),
     })
   );
 

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -121,12 +121,12 @@ describe('metrics', () => {
 
     it('has expected defaults', () => {
       const options = _setDefaultOptions();
-      assert.deepEqual(options.serviceName, 'unnamed-node-service');
+      assert.deepEqual(options.serviceName, '@splunk/otel');
       assert.deepEqual(options.accessToken, '');
       assert.deepEqual(options.exportIntervalMillis, 30000);
       assert.deepEqual(
         options.resource.attributes[SemanticResourceAttributes.SERVICE_NAME],
-        'unnamed-node-service'
+        '@splunk/otel'
       );
       assert.deepEqual(options.runtimeMetricsEnabled, true);
       assert.deepEqual(options.runtimeMetricsCollectionIntervalMillis, 5000);

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -108,7 +108,6 @@ describe('options', () => {
       );
 
       const expectedAttributes = new Set([
-        SemanticResourceAttributes.CONTAINER_ID,
         SemanticResourceAttributes.HOST_ARCH,
         SemanticResourceAttributes.HOST_NAME,
         SemanticResourceAttributes.OS_TYPE,
@@ -126,6 +125,12 @@ describe('options', () => {
           `${processAttribute} missing`
         );
       });
+
+      // Container ID is checked in a different test,
+      // this avoids collisions with stubbing fs methods.
+      delete options.tracerConfig.resource.attributes[
+        SemanticResourceAttributes.CONTAINER_ID
+      ];
 
       // resource attributes for process, host and os are different at each run, iterate through them, make sure they exist and then delete
       Object.keys(options.tracerConfig.resource.attributes)

--- a/test/profiling/profiling.test.ts
+++ b/test/profiling/profiling.test.ts
@@ -52,12 +52,12 @@ describe('profiling', () => {
     it('sets default options when no options are provided', () => {
       const options = _setDefaultOptions();
       assert.deepStrictEqual(options, {
-        serviceName: 'unnamed-node-service',
+        serviceName: '@splunk/otel',
         endpoint: 'http://localhost:4317',
         callstackInterval: 1_000,
         collectionDuration: 30_000,
         resource: new Resource({
-          [SemanticResourceAttributes.SERVICE_NAME]: 'unnamed-node-service',
+          [SemanticResourceAttributes.SERVICE_NAME]: '@splunk/otel',
         }).merge(detectResource()),
         exporterFactory: defaultExporterFactory,
         memoryProfilingEnabled: false,

--- a/test/service_name.test.ts
+++ b/test/service_name.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+import { defaultServiceName, findServiceName } from '../src/utils';
+import { cleanEnvironment } from './utils';
+import { DiagLogLevel } from '@opentelemetry/api';
+
+describe('findServiceName', () => {
+  const TMP_PREFIX = 'splunk-otel-service-name-test-';
+  const prevDir = process.cwd();
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), TMP_PREFIX));
+    process.chdir(tempDir);
+  });
+
+  it('can find package name from working directory', () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'test-service-42' })
+    );
+    assert.deepStrictEqual(findServiceName(new Map()), 'test-service-42');
+  });
+
+  it('returns undefined when package.json does not contain a name', () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({ name: 42 })
+    );
+    assert.deepStrictEqual(findServiceName(new Map()), undefined);
+  });
+
+  it('returns undefined when package name is not a string', () => {
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({}));
+    assert.deepStrictEqual(findServiceName(new Map()), undefined);
+  });
+
+  it('returns undefined when package.json is not json', () => {
+    fs.writeFileSync(path.join(tempDir, 'package.json'), 'abc');
+    assert.deepStrictEqual(findServiceName(new Map()), undefined);
+  });
+
+  it('returns undefined when package.json is not a file', () => {
+    fs.mkdirSync(path.join(tempDir, 'package.json'));
+    assert.deepStrictEqual(findServiceName(new Map()), undefined);
+  });
+
+  it('reads the name from cache', () => {
+    assert.deepStrictEqual(
+      findServiceName(new Map([['package.name', 'foo']])),
+      'foo'
+    );
+  });
+
+  it('caches the package name value', () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'xyz' })
+    );
+    const cache = new Map();
+    assert.deepStrictEqual(findServiceName(cache), 'xyz');
+    assert.deepStrictEqual(cache.get('package.name'), 'xyz');
+  });
+
+  it('returns the hardcoded name when service name can not be read', () => {
+    fs.writeFileSync(path.join(tempDir, 'package.json'), 'abc');
+    assert.deepStrictEqual(
+      defaultServiceName(new Map()),
+      'unnamed-node-service'
+    );
+  });
+});


### PR DESCRIPTION
Unless explicit service name is set, instead of defaulting to `unnamed-node-service`, an attempt will be made to read the package name from current working directory's package.json. If this can't be done or does not exist, only then is `unnamed-node-service` used.