### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @splunk/otel
 
+## 2.1.0
+
+1st of December, 2022
+
+- Deduce the service name from `package.json` if it is not explicitly configured. [#625](https://github.com/signalfx/splunk-otel-js/pull/625)
+- Fix console metric exporter omitting datapoint specific attributes. [#626](https://github.com/signalfx/splunk-otel-js/pull/626)
+
 ## 2.0.0
 
 22nd of November, 2022

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.0.0';
+export const VERSION = '2.1.0';


### PR DESCRIPTION
- Deduce the service name from `package.json` if it is not explicitly configured. [#625](https://github.com/signalfx/splunk-otel-js/pull/625)
- Fix console metric exporter omitting datapoint specific attributes. [#626](https://github.com/signalfx/splunk-otel-js/pull/626)