### PR TITLE
feat: autoinstrument: add early exit based on application name

### DIFF
--- a/test/instrument.test.ts
+++ b/test/instrument.test.ts
@@ -17,12 +17,15 @@
 import * as sinon from 'sinon';
 import * as tracing from '../src/tracing';
 import * as metrics from '../src/metrics';
+import { cleanEnvironment } from './utils';
 
 describe('instrumentation', () => {
   let startTracingMock;
   let startMetricsMock;
 
   beforeEach(() => {
+    delete require.cache[require.resolve('../src/instrument')];
+    cleanEnvironment();
     startTracingMock = sinon.stub(tracing, 'startTracing');
     startMetricsMock = sinon.stub(metrics, 'startMetrics');
   });
@@ -37,5 +40,17 @@ describe('instrumentation', () => {
   it('importing auto calls startTracing', () => {
     require('../src/instrument');
     sinon.assert.calledOnce(startTracingMock);
+  });
+
+  it('calls startTracing when SPLUNK_AUTOINSTRUMENT_PACKAGE_NAMES contains a matching package name', () => {
+    process.env.SPLUNK_AUTOINSTRUMENT_PACKAGE_NAMES = '@splunk/otel,foo';
+    require('../src/instrument');
+    sinon.assert.calledOnce(startTracingMock);
+  });
+
+  it('does not call startTracing when SPLUNK_AUTOINSTRUMENT_PACKAGE_NAMES does not contain a matching package name', () => {
+    process.env.SPLUNK_AUTOINSTRUMENT_PACKAGE_NAMES = 'foo,@splunk/zotel';
+    require('../src/instrument');
+    sinon.assert.notCalled(startTracingMock);
   });
 });


### PR DESCRIPTION
Adds a new environment variable `SPLUNK_AUTOINSTRUMENT_PACKAGE_NAMES` which can be used to specify an allowlist of package names. When set, only the packages matching the list will be autoinstrumented.