### PR TITLE
test: don't compare spans by timestamps in integration tests

### DIFF
--- a/test/examples/utils.js
+++ b/test/examples/utils.js
@@ -186,7 +186,7 @@ function compareTraces(actualRoot, expectedRoot, actualSpansByParentId, expected
       'Different amount of span children'
     );
 
-    for (let i = 0; i < childrenA.length; i++) {
+    for (let i = 0; i < actualChildren.length; i++) {
       queue.push([actualChildren[i], expectedChildren[i]]);
     }
   }

--- a/test/profiling/extension.test.ts
+++ b/test/profiling/extension.test.ts
@@ -55,7 +55,7 @@ describe('profiling native extension', () => {
       recordDebugInfo: false,
     });
 
-    utils.spinMs(200);
+    utils.spinMs(1_000);
 
     const result = extension.collect();
     // The types might not be what is declared in typescript, a sanity check.


### PR DESCRIPTION
Due to timestamp precision loss in OTLP's exporter, the spans in integration tests might have identical timestamps. This causes flaky tests.

Until https://github.com/open-telemetry/opentelemetry-js/issues/2643 gets fixed, changed the comparison to be trace shape based, i.e. parent-child relationships are checked for inside a trace.