### PR TITLE
fix: loading of mongoose instrumentation due to invalid package name

### DIFF
--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -39,6 +39,7 @@ const bundledInstrumentations: [string, string][] = [
   ['@opentelemetry/instrumentation-koa', 'KoaInstrumentation'],
   ['@opentelemetry/instrumentation-memcached', 'MemcachedInstrumentation'],
   ['@opentelemetry/instrumentation-mongodb', 'MongoDBInstrumentation'],
+  ['@opentelemetry/instrumentation-mongoose', 'MongooseInstrumentation'],
   ['@opentelemetry/instrumentation-mysql', 'MySQLInstrumentation'],
   ['@opentelemetry/instrumentation-mysql2', 'MySQL2Instrumentation'],
   ['@opentelemetry/instrumentation-nestjs-core', 'NestInstrumentation'],
@@ -56,7 +57,6 @@ const bundledInstrumentations: [string, string][] = [
     'ElasticsearchInstrumentation',
   ],
   ['opentelemetry-instrumentation-kafkajs', 'KafkaJsInstrumentation'],
-  ['opentelemetry-instrumentation-mongoose', 'MongooseInstrumentation'],
   ['opentelemetry-instrumentation-sequelize', 'SequelizeInstrumentation'],
   ['opentelemetry-instrumentation-typeorm', 'TypeormInstrumentation'],
 ];

--- a/test/instrumentations.test.ts
+++ b/test/instrumentations.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import * as assert from 'assert';
 import * as rewire from 'rewire';
 
@@ -23,14 +22,8 @@ import * as loader from '../src/instrumentations/loader';
 
 describe('instrumentations', () => {
   it('loads instrumentations if they are installed', () => {
-    const loadStub = sinon.stub(loader, 'load');
-    try {
-      const inst = instrumentations.getInstrumentations();
-      sinon.assert.callCount(loadStub, 36);
-    } finally {
-      loadStub.reset();
-      loadStub.restore();
-    }
+    const loadedInstrumentations = instrumentations.getInstrumentations();
+    assert.equal(loadedInstrumentations.length, 36);
   });
 
   it('loader silently fails when instrumentation is not installed', () => {


### PR DESCRIPTION
The instrumentation was moved to OTel, but in the 2.2.0 release only package.json was updated