### PR TITLE
fix: don't pass all shared options to signals

### DIFF
--- a/src/start.ts
+++ b/src/start.ts
@@ -18,6 +18,7 @@ import {
   getNonEmptyEnvVar,
   parseEnvBooleanString,
   parseLogLevel,
+  pick,
   toDiagLogLevel,
 } from './utils';
 import { startMetrics, StartMetricsOptions } from './metrics';
@@ -28,6 +29,9 @@ import {
 } from './profiling';
 import type { EnvVarKey, LogLevel } from './types';
 import { startTracing, stopTracing, StartTracingOptions } from './tracing';
+import { allowedTracingOptions } from './tracing/options';
+import { allowedProfilingOptions } from './profiling/types';
+import { allowedMetricsOptions } from './metrics';
 import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
 
 interface Options {
@@ -84,7 +88,10 @@ export const start = (options: Partial<Options> = {}) => {
 
   let metricsEnabledByDefault = false;
   if (isSignalEnabled(options.profiling, 'SPLUNK_PROFILER_ENABLED', false)) {
-    const profilingOptions = Object.assign({}, restOptions, profiling);
+    const profilingOptions = Object.assign(
+      pick(restOptions, allowedProfilingOptions),
+      profiling
+    );
     running.profiling = startProfiling(profilingOptions);
 
     // HACK: memory profiling needs to enable metrics,
@@ -97,7 +104,9 @@ export const start = (options: Partial<Options> = {}) => {
   }
 
   if (isSignalEnabled(options.tracing, 'SPLUNK_TRACING_ENABLED', true)) {
-    running.tracing = startTracing(Object.assign({}, restOptions, tracing));
+    running.tracing = startTracing(
+      Object.assign(pick(restOptions, allowedTracingOptions), tracing)
+    );
   }
 
   if (
@@ -107,7 +116,9 @@ export const start = (options: Partial<Options> = {}) => {
       metricsEnabledByDefault
     )
   ) {
-    running.metrics = startMetrics(Object.assign({}, restOptions, metrics));
+    running.metrics = startMetrics(
+      Object.assign(pick(restOptions, allowedMetricsOptions), metrics)
+    );
   }
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -205,3 +205,17 @@ export function parseLogLevel(value: string | undefined): DiagLogLevel {
 
   return DiagLogLevel.NONE;
 }
+
+export function pick<T extends Record<string, any>, K extends string>(
+  obj: T,
+  keys: readonly K[]
+): { [P in keyof T as P extends K ? P : never]: T[P] } {
+  const result = {} as any;
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (key in obj) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+}

--- a/test/start.test.ts
+++ b/test/start.test.ts
@@ -162,6 +162,34 @@ describe('start', () => {
       stop();
       assertCalled(signals.stop, ['tracing']);
     });
+
+    it('does not add extra configuration arguments to signals', () => {
+      start({
+        accessToken: 'xyz',
+        endpoint: 'localhost:1111',
+        serviceName: 'test',
+        logLevel: 'debug',
+        profiling: true,
+        metrics: true,
+      });
+
+      sinon.assert.calledOnceWithExactly(signals.start.tracing, {
+        accessToken: 'xyz',
+        endpoint: 'localhost:1111',
+        serviceName: 'test',
+      });
+
+      sinon.assert.calledOnceWithExactly(signals.start.profiling, {
+        endpoint: 'localhost:1111',
+        serviceName: 'test',
+      });
+
+      sinon.assert.calledOnceWithExactly(signals.start.metrics, {
+        accessToken: 'xyz',
+        endpoint: 'localhost:1111',
+        serviceName: 'test',
+      });
+    });
   });
 
   describe('configuration', () => {


### PR DESCRIPTION
Attributes meant for `start` were passed to signals. It broke when `startTracing` saw `logLevel` passed to it from `start` and errored due to the  `assertNoExtraneousProperties` check.

Solution: filter out the attributes from common config that the signals can handle.