### PR TITLE
chore: release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log - @splunk/otel
 
+## 2.3.0
+
+August 1, 2023
+
+- Upgrade to OpenTelemetry `1.15.1` / `0.41.1`. [#761](https://github.com/signalfx/splunk-otel-js/pull/761)
+- Fix confusing error message regarding `grpc`: `@opentelemetry/instrumentation-grpc Module @grpc/grpc-js has been loaded before @opentelemetry/instrumentation-grpc so it might not work, please initialize it before requiring @grpc/grpc-js`. `grpc` is internally now lazily loaded. [#762](https://github.com/signalfx/splunk-otel-js/pull/762)
+- Allow enabling and disabling instrumentations via environment variables by introducing `OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED` and `OTEL_INSTRUMENTATION_[NAME]_ENABLED`. [#769](https://github.com/signalfx/splunk-otel-js/pull/769)
+
 ## 2.2.4
 
 July 1, 2023

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.2.4",
+      "version": "2.3.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.2.4';
+export const VERSION = '2.3.0';


### PR DESCRIPTION
- Upgrade to OpenTelemetry `1.15.1` / `0.41.1`. [#761](https://github.com/signalfx/splunk-otel-js/pull/761)
- Fix confusing error message regarding `grpc`: `@opentelemetry/instrumentation-grpc Module @grpc/grpc-js has been loaded before @opentelemetry/instrumentation-grpc so it might not work, please initialize it before requiring @grpc/grpc-js`. `grpc` is internally now lazily loaded. [#762](https://github.com/signalfx/splunk-otel-js/pull/762)
- Allow enabling and disabling instrumentations via environment variables by introducing `OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED` and `OTEL_INSTRUMENTATION_[NAME]_ENABLED`. [#769](https://github.com/signalfx/splunk-otel-js/pull/769)