### PR TITLE
chore: release v2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - @splunk/otel
 
+## 2.3.2
+
+August 9, 2023
+
+- Upgrade to OpenTelemetry `1.15.2` / `0.41.2`. [#778](https://github.com/signalfx/splunk-otel-js/pull/778)
+
 ## 2.3.1
 
 August 2, 2023

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.3.1';
+export const VERSION = '2.3.2';


### PR DESCRIPTION
- Upgrade to OpenTelemetry `1.15.2` / `0.41.2`. [#778](https://github.com/signalfx/splunk-otel-js/pull/778)