### PR TITLE
fix: add workaround for OTEL_TRACES_EXPORTER logging an error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ distribution of [OpenTelemetry JS](https://github.com/open-telemetry/opentelemet
 It is licensed under the terms of the Apache Software License version 2.0. See [the
 license file](./LICENSE) for more details.
 
->ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/about-splunk/acquisitions/signalfx.html) for more information.

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -87,8 +87,11 @@ export function startTracing(opts: StartTracingOptions = {}): boolean {
     tracingContextManagerEnabled = true;
   }
 
-  // tracer provider
+  // Workaround for https://github.com/open-telemetry/opentelemetry-js/issues/3422
+  const envTracesExporter = process.env.OTEL_TRACES_EXPORTER;
+  process.env.OTEL_TRACES_EXPORTER = undefined;
   const provider = new NodeTracerProvider(options.tracerConfig);
+  process.env.OTEL_TRACES_EXPORTER = envTracesExporter;
 
   configureInstrumentations(options);
 

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -89,7 +89,7 @@ export function startTracing(opts: StartTracingOptions = {}): boolean {
 
   // Workaround for https://github.com/open-telemetry/opentelemetry-js/issues/3422
   const envTracesExporter = process.env.OTEL_TRACES_EXPORTER;
-  process.env.OTEL_TRACES_EXPORTER = undefined;
+  process.env.OTEL_TRACES_EXPORTER = '';
   const provider = new NodeTracerProvider(options.tracerConfig);
   process.env.OTEL_TRACES_EXPORTER = envTracesExporter;
 

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -89,9 +89,13 @@ export function startTracing(opts: StartTracingOptions = {}): boolean {
 
   // Workaround for https://github.com/open-telemetry/opentelemetry-js/issues/3422
   const envTracesExporter = process.env.OTEL_TRACES_EXPORTER;
-  process.env.OTEL_TRACES_EXPORTER = '';
+  if (envTracesExporter !== undefined) {
+    process.env.OTEL_TRACES_EXPORTER = '';
+  }
   const provider = new NodeTracerProvider(options.tracerConfig);
-  process.env.OTEL_TRACES_EXPORTER = envTracesExporter;
+  if (envTracesExporter !== undefined) {
+    process.env.OTEL_TRACES_EXPORTER = envTracesExporter;
+  }
 
   configureInstrumentations(options);
 


### PR DESCRIPTION
Constructing `NodeTracerProvider` with `OTEL_TRACES_EXPORTER` set logs an error, e.g. `Exporter "otlp" requested through environment variable is unavailable.` Nothing actually goes wrong, but the error message is confusing for users.


Workaround for https://github.com/open-telemetry/opentelemetry-js/issues/3422