### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @splunk/otel
 
+## 2.4.0
+
+August 18, 2023
+
+- Fix the error message about an unavailable exporter (e.g. `Exporter "otlp" requested through environment variable is unavailable.`) when `OTEL_TRACES_EXPORTER` is set. Workaround for https://github.com/open-telemetry/opentelemetry-js/issues/3422. [#783](https://github.com/signalfx/splunk-otel-js/pull/783)
+- Explicitly set a meter provider for instrumentations. `NoopMeterProvider` is set by default. If metrics are enabled and `SPLUNK_INSTRUMENTATION_METRICS_ENABLED` is set to true, instrumentation specific metrics will be emitted, for example `http.server.duration` from the `http` instrumentation. [#784](https://github.com/signalfx/splunk-otel-js/pull/784)
+
 ## 2.3.2
 
 August 9, 2023

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.3.2",
+      "version": "2.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.3.2';
+export const VERSION = '2.4.0';


### PR DESCRIPTION
- Fix the error message about an unavailable exporter (e.g. `Exporter "otlp" requested through environment variable is unavailable.`) when `OTEL_TRACES_EXPORTER` is set. Workaround for https://github.com/open-telemetry/opentelemetry-js/issues/3422. [#783](https://github.com/signalfx/splunk-otel-js/pull/783)
- Explicitly set a meter provider for instrumentations. `NoopMeterProvider` is set by default. If metrics are enabled and `SPLUNK_INSTRUMENTATION_METRICS_ENABLED` is set to true, instrumentation specific metrics will be emitted, for example `http.server.duration` from the `http` instrumentation. [#784](https://github.com/signalfx/splunk-otel-js/pull/784)