### PR TITLE
fix: missing forceFlush on noop meter provider

### DIFF
--- a/src/start.ts
+++ b/src/start.ts
@@ -44,7 +44,6 @@ import {
   DiagLogLevel,
   metrics as metricsApi,
   MeterOptions,
-  MeterProvider,
   createNoopMeter,
 } from '@opentelemetry/api';
 
@@ -146,12 +145,15 @@ export const start = (options: Partial<Options> = {}) => {
   }
 };
 
-function createNoopMeterProvider(): MeterProvider {
+function createNoopMeterProvider() {
   const meter = createNoopMeter();
   return {
     getMeter(_name: string, _version?: string, _options?: MeterOptions) {
       return meter;
     },
+    // AWS Lambda instrumentation check for the existence of forceFlush,
+    // if it does not exist, an error is logged for each span.
+    forceFlush() {},
   };
 }
 


### PR DESCRIPTION
AWS Lambda instrumentation needs a `forceFlush` method to be existing on a meter provider else it logs an error for each span. (https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts#L296)

The thing is even OTel's own `NOOP_METER_PROVIDER` doesn't have it.