### PR TITLE
fix: make noopmeterprovider forceFlush return a promise

### DIFF
--- a/src/start.ts
+++ b/src/start.ts
@@ -153,7 +153,9 @@ function createNoopMeterProvider() {
     },
     // AWS Lambda instrumentation check for the existence of forceFlush,
     // if it does not exist, an error is logged for each span.
-    forceFlush() {},
+    forceFlush() {
+      return Promise.resolve();
+    },
   };
 }
 


### PR DESCRIPTION
MeterProvider's forceFlush returns a promise:
https://github.com/open-telemetry/opentelemetry-js/blob/8ac369f87e792702045f9847c7ab4ac72aa48ce2/packages/sdk-metrics/src/MeterProvider.ts#L114

[AWS Lambda instrumentation uses `Promise.all` on the result of `forceFlush`,](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts#L356) while this works I think it's better to make it 100% compatible in case there are calls to `forceFlush().then()` anywhere