### PR TITLE
chore: release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - @splunk/otel
 
+## 2.4.1
+
+August 28, 2023
+
+- Add missing `forceFlush` method to the `NoopMeterProvider`. Some instrumentations (AWS Lambda) logged an error when `forceFlush` was unavailable. [#788](https://github.com/signalfx/splunk-otel-js/pull/788) [#791](https://github.com/signalfx/splunk-otel-js/pull/791)
+
 ## 2.4.0
 
 August 18, 2023

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.4.0';
+export const VERSION = '2.4.1';


### PR DESCRIPTION
- Add missing `forceFlush` method to the `NoopMeterProvider`. Some instrumentations (AWS Lambda) logged an error when `forceFlush` was unavailable. [#788](https://github.com/signalfx/splunk-otel-js/pull/788) [#791](https://github.com/signalfx/splunk-otel-js/pull/791)