### PR TITLE
fix: support 'none' value for OTEL_METRICS_EXPORTER

### DIFF
--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -128,7 +128,7 @@ function recordGcCountMetric(counter: Counter, counters: NativeCounters) {
   }
 }
 
-const SUPPORTED_EXPORTER_TYPES = ['console', 'otlp'];
+const SUPPORTED_EXPORTER_TYPES = ['console', 'otlp', 'none'];
 
 function areValidExporterTypes(types: string[]): boolean {
   return types.every((t) => SUPPORTED_EXPORTER_TYPES.includes(t));

--- a/test/metrics.options.test.ts
+++ b/test/metrics.options.test.ts
@@ -57,6 +57,12 @@ describe('metrics options', () => {
       assert(readers[1]['_exporter'] instanceof ConsoleMetricExporter);
     });
 
+    it('does not create an exporter for none value', () => {
+      process.env.OTEL_METRICS_EXPORTER = 'none';
+      const options = _setDefaultOptions();
+      assert.deepStrictEqual(options.metricReaderFactory(options), []);
+    });
+
     it('throws on invalid key', () => {
       process.env.OTEL_METRICS_EXPORTER = 'invalid-key';
 


### PR DESCRIPTION
The code was throwing when `OTEL_METRICS_EXPORTER=none`, but `none` [is a valid value](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection).