### PR TITLE
fix: compare kafka header keys case insensitively

### DIFF
--- a/src/instrumentations/external/kafkajs/kafkajs.ts
+++ b/src/instrumentations/external/kafkajs/kafkajs.ts
@@ -43,7 +43,7 @@ import type {
 } from 'kafkajs';
 import { KafkaJsInstrumentationConfig } from './types';
 import { VERSION } from '../../../version';
-import { bufferTextMapGetter } from './propagtor';
+import { bufferTextMapGetter } from './propagator';
 import {
   InstrumentationBase,
   InstrumentationModuleDefinition,

--- a/src/instrumentations/external/kafkajs/propagator.ts
+++ b/src/instrumentations/external/kafkajs/propagator.ts
@@ -22,7 +22,19 @@ adding toString() to make sure string is returned
 */
 export const bufferTextMapGetter: TextMapGetter = {
   get(carrier, key) {
-    return carrier?.[key]?.toString();
+    if (carrier === undefined) {
+      return undefined;
+    }
+
+    const keys = Object.keys(carrier);
+
+    for (const carrierKey of keys) {
+      if (carrierKey.toLowerCase() === key) {
+        return carrier[carrierKey]?.toString();
+      }
+    }
+
+    return undefined;
   },
 
   keys(carrier) {

--- a/src/instrumentations/external/kafkajs/propagator.ts
+++ b/src/instrumentations/external/kafkajs/propagator.ts
@@ -22,7 +22,7 @@ adding toString() to make sure string is returned
 */
 export const bufferTextMapGetter: TextMapGetter = {
   get(carrier, key) {
-    if (carrier === undefined) {
+    if (!carrier) {
       return undefined;
     }
 


### PR DESCRIPTION
OTel JS defines carrier keys as lowercase. b3 propagator attempts to read lowercase keys, but other SDKs (Java) produce headers with mixed case keys, causing split traces - https://github.com/open-telemetry/opentelemetry-js/issues/3150

This works fine in the case of HTTP, where node's http module lowercases all keys, but kafkajs retains the key casing.