### PR TITLE
chore: release v2.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log - @splunk/otel
 
+## 2.4.4
+
+- Support older libc++ ABIs. This should remove the need for a compilation step on CentOS 7 when running npm install. [#806](https://github.com/signalfx/splunk-otel-js/pull/806)
+
 ## 2.4.3
 
 - Compare kafka header values case insensitively. Fixed split traces when b3 propagation is used over kafka headers and the producer does not use lowercase keys. [#804](https://github.com/signalfx/splunk-otel-js/pull/804)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.4.3';
+export const VERSION = '2.4.4';


### PR DESCRIPTION
- Support older libc++ ABIs. This should remove the need for a compilation step on CentOS 7 when running npm install. [#806](https://github.com/signalfx/splunk-otel-js/pull/806)