### PR TITLE
Add more code towards supporting ppc64le

### DIFF
--- a/.github/workflows/test-docker-image.yml
+++ b/.github/workflows/test-docker-image.yml
@@ -1,0 +1,21 @@
+name: Test splunk-otel-js Docker image
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/test-docker-image.yml'
+
+jobs:
+  test-image:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3.5.3
+      - uses: docker/setup-buildx-action@v2
+      - name: build container
+        uses: docker/build-push-action@v4.1.1
+        with:
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
+          build-args: |
+            RELEASE_VER=${{ env.GITHUB_REF_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
-FROM node:16 AS build
+FROM node:16 AS build-amd64
+WORKDIR /splunk-otel-js
+COPY . .
+RUN npm install
+RUN npm run compile
+RUN npm run prebuild:os '14.0.0' '15.0.0' '16.0.0' '17.0.1' '18.0.0'
+RUN npm pack && tar xf splunk-otel-$(npm view @splunk/otel version).tgz
+RUN npm prune --omit=dev && cp -r node_modules/ package
+
+FROM node:16 AS build-arm64
 
 WORKDIR /splunk-otel-js
 COPY . .
@@ -8,8 +17,19 @@ RUN npm run prebuild:os '14.0.0' '15.0.0' '16.0.0' '17.0.1' '18.0.0'
 RUN npm pack && tar xf splunk-otel-$(npm view @splunk/otel version).tgz
 RUN npm prune --omit=dev && cp -r node_modules/ package
 
-FROM busybox
+FROM ppc64le/node:16 AS build-ppc64le
+WORKDIR /splunk-otel-js
+COPY . .
+RUN npm install
+RUN npm run compile
+RUN npm run prebuild:os '14.0.0' '15.0.0' '16.0.0' '17.0.1' '18.0.0'
+RUN npm pack && tar xf splunk-otel-$(npm view @splunk/otel version).tgz
+RUN npm prune --omit=dev && cp -r node_modules/ package
 
+FROM build-$TARGETARCH AS build
+
+FROM busybox
+ARG TARGETARCH
 LABEL org.opencontainers.image.source="https://github.com/signalfx/splunk-otel-js"
 LABEL org.opencontainers.image.description="Splunk Distribution of OpenTelemetry Node.js Instrumentation"
 


### PR DESCRIPTION
Since the Docker image `node` doesn't support ppc64le, we need to define the build image using a variance on the builtin argument `TARGETARCH` to build the right image. I also added some tests so changes to the Dockerfile can be tested.