### PR TITLE
chore: release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - @splunk/otel
 
+## 2.6.0
+
+- Add missing telemetry.sdk.version to profiling payloads. #[854](https://github.com/signalfx/splunk-otel-js/pull/854)
+- Upgrade to OpenTelemetry `1.18.1` / `0.45.1`. [#852](https://github.com/signalfx/splunk-otel-js/pull/852)
+- Add Linux ARM64 prebuilt binaries. [#850](https://github.com/signalfx/splunk-otel-js/pull/850)
+
 ## 2.5.1
 
 - Prebuild the native module for Node.js 21. [#838](https://github.com/signalfx/splunk-otel-js/pull/838)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.5.1';
+export const VERSION = '2.6.0';


### PR DESCRIPTION
- Add missing telemetry.sdk.version to profiling payloads. #[854](https://github.com/signalfx/splunk-otel-js/pull/854)
- Upgrade to OpenTelemetry `1.18.1` / `0.45.1`. [#852](https://github.com/signalfx/splunk-otel-js/pull/852)
- Add Linux ARM64 prebuilt binaries. [#850](https://github.com/signalfx/splunk-otel-js/pull/850)