### PR TITLE
chore: release v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @splunk/otel
 
+## 2.6.1
+
+- Fix potential memory leak when CPU profiling is active. [#858](https://github.com/signalfx/splunk-otel-js/pull/858)
+- Upgrade to protobuf.js 7.2.5. [#859](https://github.com/signalfx/splunk-otel-js/pull/859)
+
 ## 2.6.0
 
 - Add missing telemetry.sdk.version to profiling payloads. #[854](https://github.com/signalfx/splunk-otel-js/pull/854)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.6.0';
+export const VERSION = '2.6.1';


### PR DESCRIPTION
- Fix potential memory leak when CPU profiling is active. [#858](https://github.com/signalfx/splunk-otel-js/pull/858)
- Upgrade to protobuf.js 7.2.5. [#859](https://github.com/signalfx/splunk-otel-js/pull/859)