### PR TITLE
add metadata yaml generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,13 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run compile
+      - name: Generate metadata YAML
+        run: node scripts/generate-metadata-yaml.js > splunk-otel-js-metadata.yaml
+      - name: Upload metadata yaml
+        uses: actions/upload-artifact@v3
+        with:
+          name: splunk-otel-js-metadata.yaml
+          path: splunk-otel-js-metadata.yaml
 
   centos-build-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Install npm dependencies
         run: npm ci
       - name: Build

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -1,5 +1,5 @@
-> The official Splunk documentation for this page is [Configure the Splunk Distribution of OTel JS](https://quickdraw.splunk.com/redirect/?product=Observability&version=current&location=nodejs.application.config). 
-> 
+> The official Splunk documentation for this page is [Configure the Splunk Distribution of OTel JS](https://quickdraw.splunk.com/redirect/?product=Observability&version=current&location=nodejs.application.config).
+>
 > For instructions on how to contribute to the docs, see [CONTRIBUTING.md](../CONTRIBUTING.md#documentation).
 
 # Advanced Configuration
@@ -55,15 +55,15 @@ This distribution supports all the configuration options supported by the compon
 | --------------------------------------------------------------- | ----------------------- | ------- | ---
 | `OTEL_ATTRIBUTE_COUNT_LIMIT`                                    |                         | Stable  | Maximum allowed span attribute count
 | `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`                             | `12000`\*               | Stable  | Maximum allowed attribute value size
-| `OTEL_EXPORTER_OTLP_ENDPOINT`<br>`endpoint`                     | `http://localhost:4317` | Stable  | The OTLP endpoint to export to. Only OTLP over gRPC is supported.
+| `OTEL_EXPORTER_OTLP_ENDPOINT`<br>`endpoint`                     | `http://localhost:4317` | Stable  | The OTLP endpoint to export to.
 | `OTEL_LOG_LEVEL`                                                |                         | Stable  | Log level to use in diagnostics logging. **Does not set the logger.**
 | `OTEL_PROPAGATORS`<br>`tracing.propagators`                     | `tracecontext,baggage`  | Stable  | Comma-delimited list of propagators to use. Valid keys: `baggage`, `tracecontext`, `b3multi`, `b3`.
 | `OTEL_RESOURCE_ATTRIBUTES`                                      |                         | Stable  | Comma-separated list of resource attributes added to every reported span. <details><summary>Example</summary>`key1=val1,key2=val2`</details>
 | `OTEL_SERVICE_NAME`<br>`serviceName`                            | `unnamed-node-service`  | Stable  | The service name of this Node service.
 | `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`                               | `128`                   | Stable  | Maximum allowed span attribute count
 | `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`                        |                         | Stable  | Maximum allowed attribute value size. Empty value is treated as infinity
-| `OTEL_SPAN_EVENT_COUNT_LIMIT`                                   | `128`                   | Stable  | 
-| `OTEL_SPAN_LINK_COUNT_LIMIT`                                    | `1000`\*                | Stable  | 
+| `OTEL_SPAN_EVENT_COUNT_LIMIT`                                   | `128`                   | Stable  |
+| `OTEL_SPAN_LINK_COUNT_LIMIT`                                    | `1000`\*                | Stable  |
 | `OTEL_TRACES_EXPORTER`<br>`tracing.spanExporterFactory`         | `otlp`                  | Stable  | Chooses the trace exporters. Shortcut for setting `spanExporterFactory`. Comma-delimited list of exporters. Currently supported values: `otlp`, `console`.
 | `OTEL_TRACES_SAMPLER`                                           | `parentbased_always_on` | Stable  | Sampler to be used for traces. See [Sampling](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampling)
 | `OTEL_TRACES_SAMPLER_ARG`                                       |                         | Stable  | String value to be used as the sampler argument. Only be used if OTEL_TRACES_SAMPLER is set.

--- a/scripts/generate-metadata-yaml.js
+++ b/scripts/generate-metadata-yaml.js
@@ -1,0 +1,177 @@
+const { join } = require("path");
+const { readFile } = require("node:fs/promises");
+
+const { getInstrumentations } = require('../lib/instrumentations');
+
+const LOADED_INSTRUMENTATIONS = getInstrumentations();
+
+const KNOWN_TARGET_LIBRARY_VERSIONS = new Map([
+  ["splunk-opentelemetry-instrumentation-elasticsearch", [">=5 <8"]],
+  ["splunk-opentelemetry-instrumentation-kafkajs", ["*"]],
+  ["splunk-opentelemetry-instrumentation-sequelize", ["*"]],
+  ["splunk-opentelemetry-instrumentation-typeorm", [">0.2.28"]],
+  ["@opentelemetry/instrumentation-dns", ["*"]],
+  ["@opentelemetry/instrumentation-net", ["*"]],
+  ["@opentelemetry/instrumentation-http",  ["*"]],
+  ["@opentelemetry/instrumentation-grpc", ["1.x"]],
+  ["@opentelemetry/instrumentation-aws-sdk",  ["2.x", "3.x"]],
+  ["@opentelemetry/instrumentation-redis", ["^2.6.0", "3.x"]],
+  ["@opentelemetry/instrumentation-redis-4", ["4.x"]]
+]);
+
+const INSTRUMENTATIONS = [
+  { name: "@opentelemetry/instrumentation-amqplib", target: "amqplib", },
+  { name: "@opentelemetry/instrumentation-aws-sdk", target: "aws-sdk and @aws-sdk", },
+  { name: "@opentelemetry/instrumentation-bunyan", target: "bunyan", },
+  { name: "@opentelemetry/instrumentation-cassandra-driver", target: "cassandra-driver", },
+  { name: "@opentelemetry/instrumentation-connect", target: "connect", },
+  { name: "@opentelemetry/instrumentation-dataloader", target: "dataloader", },
+  { name: "@opentelemetry/instrumentation-dns", target: "dns", },
+  { name: "@opentelemetry/instrumentation-express", target: "express", },
+  { name: "@opentelemetry/instrumentation-fastify", target: "fastify", },
+  { name: "@opentelemetry/instrumentation-generic-pool", target: "generic-pool", },
+  { name: "@opentelemetry/instrumentation-graphql",  target: "graphql", },
+  { name: "@opentelemetry/instrumentation-grpc", target: "@grpc/grpc-js", },
+  { name: "@opentelemetry/instrumentation-hapi", target: "hapi", },
+  { name: "@opentelemetry/instrumentation-http", target: "http", },
+  { name: "@opentelemetry/instrumentation-ioredis", target: "ioredis", },
+  { name: "@opentelemetry/instrumentation-knex", target: "knex", },
+  { name: "@opentelemetry/instrumentation-koa", target: "koa", },
+  { name: "@opentelemetry/instrumentation-memcached", target: "memcached", },
+  { name: "@opentelemetry/instrumentation-mongodb", target: "mongodb", },
+  { name: "@opentelemetry/instrumentation-mongoose", target: "mongoose", },
+  { name: "@opentelemetry/instrumentation-mysql", target: "mysql", },
+  { name: "@opentelemetry/instrumentation-mysql2", target: "mysql2", },
+  { name: "@opentelemetry/instrumentation-nestjs-core", target: "@nestjs/core", },
+  { name: "@opentelemetry/instrumentation-net", target: "net", },
+  { name: "@opentelemetry/instrumentation-pg", target: "pg", },
+  { name: "@opentelemetry/instrumentation-pino", target: "pino", },
+  { name: "@opentelemetry/instrumentation-redis", target: "redis", },
+  { name: "@opentelemetry/instrumentation-redis-4", target: "redis", },
+  { name: "@opentelemetry/instrumentation-restify", target: "restify", },
+  { name: "@opentelemetry/instrumentation-router", target: "router", },
+  { name: "@opentelemetry/instrumentation-tedious", target: "tedious", },
+  { name: "@opentelemetry/instrumentation-winston", target: "winston", },
+  { name: "splunk-opentelemetry-instrumentation-elasticsearch", target: "@elastic/elasticsearch", support: "supported", },
+  { name: "splunk-opentelemetry-instrumentation-kafkajs", target: "kafkajs", support: "supported", },
+  { name: "splunk-opentelemetry-instrumentation-sequelize", target: "sequelize", support: "supported", },
+  { name: "splunk-opentelemetry-instrumentation-typeorm", target: "typeorm", support: "supported", },
+];
+
+async function getSupportedVersion(instrumentation) {
+  const name = instrumentation.instrumentationName;
+
+  const versions = KNOWN_TARGET_LIBRARY_VERSIONS.get(name);
+
+  if (versions !== undefined) {
+    return versions;
+  }
+
+  return await readMeVersions(name);
+}
+
+function isSpace(s) {
+  return s === " " || s === "\t" || s === "\n" || s === "\r";
+}
+
+async function readMeVersions(instrumentationName) {
+  const path = require.resolve(instrumentationName);
+  const readmePath = join(path, "../../../README.md");
+
+  const readMe = (await readFile(readmePath, { encoding: "utf8" })).toLowerCase();
+
+  const supportedVersionsHeader = "# supported versions";
+  let loc = readMe.indexOf(supportedVersionsHeader);
+
+  if (loc === -1) {
+    throw new Error(`Versions not found for ${instrumentationName}`);
+  }
+
+  loc += supportedVersionsHeader.length;
+
+  let token = readMe.charAt(loc);
+
+  while (isSpace(token)) {
+    loc += 1;
+    token = readMe.charAt(loc);
+  }
+
+  const nextHashLoc = readMe.indexOf("#", loc);
+
+  return versionLines = readMe
+    .substring(loc, nextHashLoc)
+    .split("\n")
+    .filter(s => s.length > 0)
+    .map((s) => {
+      return s.replaceAll("`", "").replaceAll("`", "").replace("- ", "");
+    });
+}
+
+async function getSupportedLibraryVersions(instrumentations) {
+  const versions = await Promise.all(instrumentations.map(i => getSupportedVersion(i)));
+
+  const versionsByInstrumentation = {};
+
+  versions.forEach((v, i) => {
+    versionsByInstrumentation[instrumentations[i].instrumentationName] = v;
+  });
+
+  return versionsByInstrumentation;
+}
+
+function getSettingsList() {
+  const { listEnvVars } = require("../lib");
+  return listEnvVars();
+}
+
+function populateSettings(lines) {
+  const settings = getSettingsList();
+  lines.push("settings:");
+
+  function addSetting(setting) {
+    lines.push(`- name: ${setting.name}`);
+    lines.push(`  description: ${setting.description}`);
+    lines.push(`  default: ${setting.default}`);
+    lines.push(`  type: ${setting.type}`);
+    lines.push(`  category: ${setting.category}`);
+  }
+
+  for (const setting of settings) {
+    addSetting(setting);
+  }
+
+  return lines;
+}
+
+async function populateInstrumentations(lines) {
+  const versions = await getSupportedLibraryVersions(LOADED_INSTRUMENTATIONS);
+
+  for (const instrumentation of INSTRUMENTATIONS) {
+    lines.push(
+      "- keys:",
+      `  - "${instrumentation.name}"`,
+      "  instrumented_components:",
+      `  - name: "${instrumentation.target}"`,
+      `    supported_versions: "${versions[instrumentation.name]}"`,
+      `  support: ${instrumentation.support ?? "community"}`,
+    );
+  }
+
+  return lines;
+}
+
+async function genMetadata() {
+  let lines = [
+    "component: Splunk Distribution of OpenTelemetry JavaScript",
+    `version: ${require("../package.json").version}`,
+  ];
+
+  lines = populateSettings(lines);
+  lines = await populateInstrumentations(lines);
+
+  const yaml = lines.join("\n");
+  process.stdout.write(yaml);
+  process.stdout.write("\n");
+}
+
+genMetadata();

--- a/scripts/generate-metadata-yaml.js
+++ b/scripts/generate-metadata-yaml.js
@@ -215,6 +215,70 @@ async function populateInstrumentations(writer) {
   writer.popIndent();
 }
 
+function populateResourceDetectors(writer) {
+  const detectors = [
+    {
+      key: "PROCESS",
+      description: "Process info detector",
+      attributes: [
+        "process.pid",
+        "process.executable.path",
+        "process.runtime.version",
+        "process.runtime.name",
+      ],
+    },
+    {
+      key: "OS",
+      description: "Operating system detector",
+      attributes: [
+        "os.type",
+        "os.description",
+      ],
+    },
+    {
+      key: "HOST",
+      description: "Host detector",
+      attributes: [
+        "host.name",
+        "host.arch"
+      ],
+    },
+    {
+      key: "CONTAINER",
+      description: "Container ID detector",
+      attributes: [
+        "container.id",
+      ],
+    },
+    {
+      key: "DISTRO",
+      description: "Distribution version detector",
+      attributes: [
+        "splunk.distro.version",
+      ],
+    }
+  ];
+
+  writer.push("resource_detectors:");
+  writer.pushIndent(2);
+
+  for (const detector of detectors) {
+    writer.push(`- key: ${detector.key}`);
+    writer.pushIndent(2);
+    writer.push(`description: ${detector.description}`),
+    writer.push("attributes:")
+    writer.pushIndent(2);
+
+    for (const attr of detector.attributes) {
+      writer.push(`- id: ${attr}`);
+    }
+
+    writer.popIndent();
+    writer.push("support: supported");
+    writer.popIndent();
+  }
+}
+
 async function genMetadata() {
   const writer = new LineWriter();
   writer.push([
@@ -224,6 +288,7 @@ async function genMetadata() {
 
   populateSettings(writer);
   await populateInstrumentations(writer);
+  populateResourceDetectors(writer);
 
   const yaml = writer.join();
   process.stdout.write(yaml);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export {
 } from './metrics/ConsoleMetricExporter';
 import { startProfiling as _startProfiling } from './profiling';
 export { start, stop } from './start';
+export { listEnvVars } from './utils';
 
 export const startMetrics = deprecate(
   _startMetrics,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -219,3 +219,253 @@ export function pick<T extends Record<string, any>, K extends string>(
   }
   return result;
 }
+
+export function listEnvVars() {
+  return [
+    {
+      name: 'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT',
+      description: 'Maximum allowed attribute value size',
+      default: '12000',
+      type: 'number',
+      category: 'instrumentation',
+    },
+    {
+      name: 'OTEL_BSP_SCHEDULE_DELAY',
+      description:
+        'The delay in milliseconds between 2 consecutive bath span processor exports.',
+      default: '500',
+      type: 'number',
+      category: 'instrumentation',
+    },
+    {
+      name: 'OTEL_EXPORTER_OTLP_CERTIFICATE',
+      description:
+        "Path to a certificate to use when verifying a server's TLS credentials.",
+      default: '',
+      type: 'string',
+      category: 'exporter',
+    },
+    {
+      name: 'OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE',
+      description:
+        "Path to a certificate to use when verifying a client's TLS credentials.",
+      default: '',
+      type: 'string',
+      category: 'exporter',
+    },
+    {
+      name: 'OTEL_EXPORTER_OTLP_CLIENT_KEY',
+      description:
+        "Path to client's private key to use in mTLS communication in PEM format.",
+      default: '',
+      type: 'string',
+      category: 'exporter',
+    },
+    {
+      name: 'OTEL_EXPORTER_OTLP_ENDPOINT',
+      description: 'The OTLP endpoint to export to.',
+      default: 'http://localhost:4317',
+      type: 'string',
+      category: 'exporter',
+    },
+    {
+      name: 'OTEL_EXPORTER_OTLP_TRACES_PROTOCOL',
+      description:
+        'Chooses the trace exporter protocol. Allowed values are grpc and http/protobuf',
+      default: 'grpc',
+      type: 'string',
+      category: 'exporter',
+    },
+    {
+      name: 'OTEL_EXPORTER_OTLP_METRICS_PROTOCOL',
+      description:
+        'Chooses the metric exporter protocol. Allowed values are grpc and http/protobuf',
+      default: 'grpc',
+      type: 'string',
+      category: 'exporter',
+    },
+    {
+      name: 'OTEL_EXPORTER_OTLP_PROTOCOL',
+      description: 'The protocol to use for OTLP exports.',
+      default: 'grpc',
+      type: 'string',
+      category: 'exporter',
+    },
+    {
+      name: 'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
+      description: 'The traces OTLP endpoint to export to.',
+      default: 'http://localhost:4317',
+      type: 'string',
+      category: 'exporter',
+    },
+    {
+      name: 'OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED',
+      description:
+        'Whether to activate all the embedded instrumentations. When you set this setting to false, use OTEL_INSTRUMENTATION_<NAME>_ENABLED=true to selectively turn on instrumentations.',
+      default: 'true',
+      type: 'boolean',
+      category: 'instrumentation',
+    },
+    {
+      name: 'OTEL_LOG_LEVEL',
+      description:
+        'Log level for the OpenTelemetry diagnostic console logger. To activate debug logging, set the debug value. Available values are error, info, debug, and verbose.',
+      default: 'none',
+      type: 'string',
+      category: 'general',
+    },
+    {
+      name: 'OTEL_METRIC_EXPORT_INTERVAL',
+      description:
+        'The interval, in milliseconds, of metrics collection and exporting.',
+      default: '30000',
+      type: 'number',
+      category: 'exporter',
+    },
+    {
+      name: 'OTEL_METRICS_EXPORTER',
+      description:
+        'Comma-separated list of metrics exporter to use. To output to the console, set the variable to console. If set to none, metric exports are turned off.',
+      default: 'otlp',
+      type: 'string',
+      category: 'exporter',
+    },
+    {
+      name: 'OTEL_PROPAGATORS',
+      description: 'Comma-separated list of propagators you want to use.',
+      default: 'tracecontext,baggage',
+      type: 'string',
+      category: 'general',
+    },
+    {
+      name: 'OTEL_SERVICE_NAME',
+      description:
+        'Name of the service or application you’re instrumenting. Takes precedence over the service name defined in the OTEL_RESOURCE_ATTRIBUTES variable.',
+      default: 'unnamed-node-service',
+      type: 'string',
+      category: 'general',
+    },
+    {
+      name: 'OTEL_SPAN_LINK_COUNT_LIMIT',
+      description: 'Maximum number of links per span.',
+      default: '1000',
+      type: 'number',
+      category: 'general',
+    },
+    {
+      name: 'OTEL_TRACES_EXPORTER',
+      description:
+        'Comma-separated list of trace exporters to use. To output to the console, set the variable to console.',
+      default: 'otlp',
+      type: 'string',
+      category: 'exporter',
+    },
+    {
+      name: 'SPLUNK_ACCESS_TOKEN',
+      description:
+        'A Splunk authentication token that lets exporters send data directly to Splunk Observability Cloud. Required if you need to send data to the Splunk Observability Cloud ingest endpoint.',
+      default: '',
+      type: 'string',
+      category: 'general',
+    },
+    {
+      name: 'SPLUNK_INSTRUMENTATION_METRICS_ENABLED',
+      description:
+        'Emit metrics from instrumentation (e.g. http.server.duration)',
+      default: 'false',
+      type: 'boolean',
+      category: 'instrumentation',
+    },
+    {
+      name: 'SPLUNK_METRICS_ENABLED',
+      description: 'Activates metrics collection.',
+      default: 'false',
+      type: 'boolean',
+      category: 'general',
+    },
+    {
+      name: 'SPLUNK_METRICS_ENDPOINT',
+      description:
+        'The metrics endpoint. Takes precedence over OTEL_EXPORTER_OTLP_METRICS_ENDPOINT. When SPLUNK_REALM is used, the default value is https://ingest.<realm>.signalfx.com/v2/datapoint/otlp.',
+      default: '',
+      type: 'string',
+      category: 'general',
+    },
+    {
+      name: 'SPLUNK_PROFILER_CALL_STACK_INTERVAL',
+      description:
+        'Frequency with which call stacks are sampled, in milliseconds.',
+      default: '1000',
+      type: 'number',
+      category: 'profiler',
+    },
+    {
+      name: 'SPLUNK_PROFILER_ENABLED',
+      description: 'Activates AlwaysOn CPU profiling.',
+      default: 'false',
+      type: 'boolean',
+      category: 'profiler',
+    },
+    {
+      name: 'SPLUNK_PROFILER_LOGS_ENDPOINT',
+      description: 'The collector endpoint for profiler logs.',
+      default: 'http://localhost:4317',
+      type: 'string',
+      category: 'profiler',
+    },
+    {
+      name: 'SPLUNK_PROFILER_MEMORY_ENABLED',
+      description: 'Activates memory profiling for AlwaysOn Profiling.',
+      default: 'false',
+      type: 'string',
+      category: 'profiler',
+    },
+    {
+      name: 'SPLUNK_REALM',
+      description:
+        'The name of your organization’s realm, for example, us0. When you set the realm, telemetry is sent directly to the ingest endpoint of Splunk Observability Cloud, bypassing the Splunk Distribution of OpenTelemetry Collector.',
+      default: '',
+      type: 'string',
+      category: 'general',
+    },
+    {
+      name: 'SPLUNK_REDIS_INCLUDE_COMMAND_ARGS',
+      description:
+        'Whether to include the full Redis query in db.statement span attributes when using the Redis instrumentation.',
+      default: 'false',
+      type: 'boolean',
+      category: 'instrumentation',
+    },
+    {
+      name: 'SPLUNK_RUNTIME_METRICS_COLLECTION_INTERVAL',
+      description:
+        'The interval, in milliseconds, during which GC and event loop statistics are collected.',
+      default: '5000',
+      type: 'number',
+      category: 'instrumentation',
+    },
+    {
+      name: 'SPLUNK_RUNTIME_METRICS_ENABLED',
+      description:
+        'Activates the collection and export of runtime metrics. Runtime metrics are only sent if the SPLUNK_METRICS_ENABLED environment variable is set to true or if memory profiling is activated.',
+      default: 'true',
+      type: 'boolean',
+      category: 'instrumentation',
+    },
+    {
+      name: 'SPLUNK_TRACE_RESPONSE_HEADER_ENABLED',
+      description:
+        'Activates the addition of server trace information to HTTP response headers.',
+      default: 'true',
+      type: 'boolean',
+      category: 'general',
+    },
+    {
+      name: 'SPLUNK_TRACING_ENABLED',
+      description: 'Enables tracing.',
+      default: 'true',
+      type: 'boolean',
+      category: 'instrumentation',
+    },
+  ];
+}


### PR DESCRIPTION
If possible the instrumentation target library versions are taken from dependency READMEs (however in the future a better mechanism is needed to gather these automatically, something to discuss in the JS sig).

Example yaml can be seen at https://github.com/signalfx/splunk-otel-js/actions/runs/7474145786/artifacts/1159275535
