### PR TITLE
chore: release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @splunk/otel
 
+## 2.7.0
+
+- Upgrade to OpenTelemetry `1.21.0` / `0.48.0`. [#874](https://github.com/signalfx/splunk-otel-js/pull/874)
+- GraphQL instrumentation: spans for resolvers are no longer generated. This brings in significant performance improvements for queries hitting lots of resolvers. `SPLUNK_GRAPHQL_RESOLVE_SPANS_ENABLED=true` environment variable can be used to unignore resolve spans.
+
 ## 2.6.1
 
 - Fix potential memory leak when CPU profiling is active. [#858](https://github.com/signalfx/splunk-otel-js/pull/858)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.6.1",
+      "version": "2.7.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.6.1';
+export const VERSION = '2.7.0';


### PR DESCRIPTION
- Upgrade to OpenTelemetry `1.21.0` / `0.48.0`. [#874](https://github.com/signalfx/splunk-otel-js/pull/874)
- GraphQL instrumentation: spans for resolvers are no longer generated. This brings in significant performance improvements for queries hitting lots of resolvers. `SPLUNK_GRAPHQL_RESOLVE_SPANS_ENABLED=true` environment variable can be used to unignore resolve spans.