### PR TITLE
fix: reported profiling stack frame count

### DIFF
--- a/test/profiling/exporter.test.ts
+++ b/test/profiling/exporter.test.ts
@@ -104,7 +104,7 @@ describe('profiling OTLP exporter', () => {
             key: 'com.splunk.sourcetype',
             value: { stringValue: 'otel.profiling' },
           },
-          { key: 'profiling.data.total.frame.count', value: { intValue: 1 } },
+          { key: 'profiling.data.total.frame.count', value: { intValue: 2 } },
         ]);
 
         done();


### PR DESCRIPTION
`profiling.data.total.frame.count` should be the amount of total frames, not stacktraces.