### PR TITLE
chore: release v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @splunk/otel
 
+## 2.9.0
+
+- Upgrade to OpenTelemetry `1.25.1` / `0.52.1`. [#912](https://github.com/signalfx/splunk-otel-js/pull/912)
+- Use kafkajs instrumentation from upstream. [#913](https://github.com/signalfx/splunk-otel-js/pull/913)
+
 ## 2.8.0
 
 - Upgrade to OpenTelemetry `1.24.0` / `0.51.0`. [#902](https://github.com/signalfx/splunk-otel-js/pull/902)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.8.0';
+export const VERSION = '2.9.0';


### PR DESCRIPTION
- Upgrade to OpenTelemetry `1.25.1` / `0.52.1`. [#912](https://github.com/signalfx/splunk-otel-js/pull/912)
- Use kafkajs instrumentation from upstream. [#913](https://github.com/signalfx/splunk-otel-js/pull/913)