### PR TITLE
chore: release v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @splunk/otel
 
+## 2.10.0
+
+- Use environment, process, host and OS detectors from upstream. Update container detector to support cgroup v2. [#925](https://github.com/signalfx/splunk-otel-js/pull/925)
+- Use explicit imports when loading instrumentations [#926](https://github.com/signalfx/splunk-otel-js/pull/926)
+
 ## 2.9.0
 
 - Upgrade to OpenTelemetry `1.25.1` / `0.52.1`. [#912](https://github.com/signalfx/splunk-otel-js/pull/912)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.9.0';
+export const VERSION = '2.10.0';


### PR DESCRIPTION
- Use environment, process, host and OS detectors from upstream. Update container detector to support cgroup v2. [#925](https://github.com/signalfx/splunk-otel-js/pull/925)
- Use explicit imports when loading instrumentations [#926](https://github.com/signalfx/splunk-otel-js/pull/926)