### PR TITLE
chore: release v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log - @splunk/otel
 
+## 2.12.0
+
+- Add `resourceFactory` option for traces. Allows for customization of the detected resource. Previously a resource could be provided via `tracerConfig`, but this overwrote the detected attributes. For backwards compatibility the latter option is still possible. [#938](https://github.com/signalfx/splunk-otel-js/pull/938)
+- Support `none` value for `OTEL_TRACES_EXPORTER` and `OTEL_METRICS_EXPORTER` environment variables. [#939](https://github.com/signalfx/splunk-otel-js/pull/939)
+- Use the default `OTEL_BSP_SCHEDULE_DELAY` of `5000` instead of `500`. This was a workaround for an old `BatchSpanProcessor` bug where it failed to flush spans fully. [#940](https://github.com/signalfx/splunk-otel-js/pull/940)
+- Disable log sending for Winston instrumentation by default. Add `winston-transport` package as a dependency in case log collection is enabled. [#941](https://github.com/signalfx/splunk-otel-js/pull/941)
+- Use a synchronous container detector from upstream. [#944](https://github.com/signalfx/splunk-otel-js/pull/944)
+- Add deprecation annotations to signal-specific start calls. [#885](https://github.com/signalfx/splunk-otel-js/pull/885)
+- Upgrade to OpenTelemetry `1.26.0` / `0.53.0`. [#945](https://github.com/signalfx/splunk-otel-js/pull/945)
+
 ## 2.11.0
 
 - Bundle instrumentations for `undici`, `socket.io` and `lru-memoizer` by default. [#934](https://github.com/signalfx/splunk-otel-js/pull/934)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.11.0';
+export const VERSION = '2.12.0';


### PR DESCRIPTION
- Add `resourceFactory` option for traces. Allows for customization of the detected resource. Previously a resource could be provided via `tracerConfig`, but this overwrote the detected attributes. For backwards compatibility the latter option is still possible. [#938](https://github.com/signalfx/splunk-otel-js/pull/938)
- Support `none` value for `OTEL_TRACES_EXPORTER` and `OTEL_METRICS_EXPORTER` environment variables. [#939](https://github.com/signalfx/splunk-otel-js/pull/939)
- Use the default `OTEL_BSP_SCHEDULE_DELAY` of `5000` instead of `500`. This was a workaround for an old `BatchSpanProcessor` bug where it failed to flush spans fully. [#940](https://github.com/signalfx/splunk-otel-js/pull/940)
- Disable log sending for Winston instrumentation by default. Add `winston-transport` package as a dependency in case log collection is enabled. [#941](https://github.com/signalfx/splunk-otel-js/pull/941)
- Use a synchronous container detector from upstream. [#944](https://github.com/signalfx/splunk-otel-js/pull/944)
- Add deprecation annotations to signal-specific start calls. [#885](https://github.com/signalfx/splunk-otel-js/pull/885)
- Upgrade to OpenTelemetry `1.26.0` / `0.53.0`. [#945](https://github.com/signalfx/splunk-otel-js/pull/945)