### PR TITLE
chore: release v2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log - @splunk/otel
 
+## 2.13.0
+
+- Add an optional workaround for Next.js span cardinality issues. Can be enabled by setting `SPLUNK_NEXTJS_FIX_ENABLED` to `true`. [#957](https://github.com/signalfx/splunk-otel-js/pull/957)
+
 ## 2.12.0
 
 - Add `resourceFactory` option for traces. Allows for customization of the detected resource. Previously a resource could be provided via `tracerConfig`, but this overwrote the detected attributes. For backwards compatibility the latter option is still possible. [#938](https://github.com/signalfx/splunk-otel-js/pull/938)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.12.0';
+export const VERSION = '2.13.0';


### PR DESCRIPTION
- Add an optional workaround for Next.js span cardinality issues. Can be enabled by setting `SPLUNK_NEXTJS_FIX_ENABLED` to `true`. [#957](https://github.com/signalfx/splunk-otel-js/pull/957)