### PR TITLE
Run released package e2e tests from 2.x branch

### DIFF
--- a/.github/workflows/e2e-test-released-package.yml
+++ b/.github/workflows/e2e-test-released-package.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: 2.x
       - name: Get versions
         run: |
           docker compose version;


### PR DESCRIPTION
The tests on the main branch have been changed and aren't compatible with the released 2.x packages