### PR TITLE
start API improvements

### DIFF
--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -14,28 +14,11 @@
  * limitations under the License.
  */
 
-import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
-import {
-  defaultServiceName,
-  getEnvArray,
-  getEnvBoolean,
-  getNonEmptyEnvVar,
-  parseLogLevel,
-} from './utils';
+import { defaultServiceName, getEnvArray, getNonEmptyEnvVar } from './utils';
 
-import { startMetrics } from './metrics';
-import { startProfiling } from './profiling';
-import { startTracing } from './tracing';
-import { startLogging } from './logging';
-import { parseOptionsAndConfigureInstrumentations } from './instrumentations';
+import { start } from './start';
 
 function boot() {
-  const logLevel = parseLogLevel(getNonEmptyEnvVar('OTEL_LOG_LEVEL'));
-
-  if (logLevel !== DiagLogLevel.NONE) {
-    diag.setLogger(new DiagConsoleLogger(), logLevel);
-  }
-
   if (getNonEmptyEnvVar('SPLUNK_AUTOINSTRUMENT_PACKAGE_NAMES') !== undefined) {
     const limitToPackages = getEnvArray(
       'SPLUNK_AUTOINSTRUMENT_PACKAGE_NAMES',
@@ -47,25 +30,7 @@ function boot() {
     }
   }
 
-  const { tracingOptions, loggingOptions, profilingOptions, metricsOptions } =
-    parseOptionsAndConfigureInstrumentations();
-
-  if (getEnvBoolean('SPLUNK_PROFILER_ENABLED', false)) {
-    startProfiling(profilingOptions);
-  }
-
-  startTracing(tracingOptions);
-
-  if (getEnvBoolean('SPLUNK_AUTOMATIC_LOG_COLLECTION', false)) {
-    startLogging(loggingOptions);
-  }
-
-  if (
-    getEnvBoolean('SPLUNK_METRICS_ENABLED', false) ||
-    getEnvBoolean('SPLUNK_PROFILER_MEMORY_ENABLED', false)
-  ) {
-    startMetrics(metricsOptions);
-  }
+  start();
 }
 
 boot();

--- a/src/instrumentations/http.ts
+++ b/src/instrumentations/http.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { CaptureHttpUriParameters } from '../tracing/options';
-import { Options as TracingOptions } from '../tracing/options';
+import type {
+  CaptureHttpUriParameters,
+  TracingOptions,
+} from '../tracing/types';
 import { IncomingMessage, ServerResponse } from 'http';
 import {
   HttpResponseCustomAttributeFunction,

--- a/src/logging/types.ts
+++ b/src/logging/types.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { LogRecordProcessor } from '@opentelemetry/sdk-logs';
+import type { Resource } from '@opentelemetry/resources';
+import type { ResourceFactory } from '../types';
+
+export type LogRecordProcessorFactory = (
+  options: LoggingOptions
+) => LogRecordProcessor | LogRecordProcessor[];
+
+export interface LoggingOptions {
+  accessToken?: string;
+  realm?: string;
+  serviceName: string;
+  endpoint?: string;
+  resource: Resource;
+  logRecordProcessorFactory: LogRecordProcessorFactory;
+}
+
+export type StartLoggingOptions = Partial<Omit<LoggingOptions, 'resource'>> & {
+  resourceFactory?: ResourceFactory;
+};

--- a/src/metrics/types.ts
+++ b/src/metrics/types.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ResourceFactory } from '../types';
+import type { MetricReader, View } from '@opentelemetry/sdk-metrics';
+import type { Resource } from '@opentelemetry/resources';
+
+export type MetricReaderFactory = (options: MetricsOptions) => MetricReader[];
+
+export interface MetricsOptions {
+  accessToken: string;
+  realm?: string;
+  serviceName: string;
+  endpoint?: string;
+  resource: Resource;
+  views?: View[];
+  exportIntervalMillis: number;
+  metricReaderFactory: MetricReaderFactory;
+  debugMetricsEnabled: boolean;
+  runtimeMetricsEnabled: boolean;
+  runtimeMetricsCollectionIntervalMillis: number;
+}
+
+export type StartMetricsOptions = Partial<Omit<MetricsOptions, 'resource'>> & {
+  resourceFactory?: ResourceFactory;
+};

--- a/src/profiling/types.ts
+++ b/src/profiling/types.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Resource } from '@opentelemetry/resources';
+import type { Resource } from '@opentelemetry/resources';
+import type { ResourceFactory } from '../types';
 
 export interface ProfilingStartOptions {
   samplingIntervalMicroseconds: number;
@@ -102,20 +103,13 @@ export interface ProfilingOptions {
   memoryProfilingOptions?: MemoryProfilingOptions;
 }
 
-export type StartProfilingOptions = Partial<ProfilingOptions>;
+export type StartProfilingOptions = Partial<
+  Omit<ProfilingOptions, 'resource'>
+> & {
+  resourceFactory?: ResourceFactory;
+};
 
 export interface ProfilingExporter {
   send(profile: CpuProfile): Promise<void>;
   sendHeapProfile(profile: HeapProfile): Promise<void>;
 }
-
-export const allowedProfilingOptions = [
-  'callstackInterval',
-  'collectionDuration',
-  'endpoint',
-  'resource',
-  'serviceName',
-  'exporterFactory',
-  'memoryProfilingEnabled',
-  'memoryProfilingOptions',
-];

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -34,6 +34,8 @@ const detectors = [
   processDetectorSync,
 ];
 
+let detectedResource: Resource | undefined;
+
 export const detect = (): Resource => {
   return detectors
     .map((detector) => {
@@ -48,3 +50,15 @@ export const detect = (): Resource => {
       return acc.merge(resource);
     }, Resource.empty());
 };
+
+export function getDetectedResource(): Resource {
+  if (detectedResource === undefined) {
+    detectedResource = detect();
+  }
+
+  return detectedResource;
+}
+
+export function clearResource() {
+  detectedResource = undefined;
+}

--- a/src/start.ts
+++ b/src/start.ts
@@ -39,12 +39,15 @@ import {
   createNoopMeter,
 } from '@opentelemetry/api';
 import { StartLoggingOptions, startLogging } from './logging';
+import { Resource } from '@opentelemetry/resources';
 
 export interface Options {
   accessToken: string;
   endpoint: string;
+  realm: string;
   serviceName: string;
   logLevel?: LogLevel;
+  resource?: (detectedResource: Resource) => Resource;
   // Signal-specific configuration options:
   metrics: boolean | StartMetricsOptions;
   profiling: boolean | StartProfilingOptions;

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -34,8 +34,10 @@ import {
   AsyncHooksContextManager,
   AsyncLocalStorageContextManager,
 } from '@opentelemetry/context-async-hooks';
-import { Options } from './options';
+import type { StartTracingOptions, TracingOptions } from './types';
 import { isProfilingContextManagerSet } from '../profiling';
+
+export type { StartTracingOptions, TracingOptions };
 
 /**
  * We disallow calling `startTracing` twice because:
@@ -79,8 +81,7 @@ function setLoadedInstrumentations(
   }
 }
 
-export type StartTracingOptions = Partial<Options>;
-export function startTracing(options: Options): boolean {
+export function startTracing(options: TracingOptions): boolean {
   assert(!isStarted, 'Splunk APM already started');
   isStarted = true;
 

--- a/src/tracing/types.ts
+++ b/src/tracing/types.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  SpanExporter,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import type { NodeTracerConfig } from '@opentelemetry/sdk-trace-node';
+import type { Span, TextMapPropagator } from '@opentelemetry/api';
+import type { Instrumentation } from '@opentelemetry/instrumentation';
+import type { ResourceFactory } from '../types';
+
+export type SpanExporterFactory = (
+  options: TracingOptions
+) => SpanExporter | SpanExporter[];
+
+export type SpanProcessorFactory = (
+  options: TracingOptions
+) => SpanProcessor | SpanProcessor[];
+
+export type PropagatorFactory = (options: TracingOptions) => TextMapPropagator;
+
+export type CaptureHttpUriParameters = (
+  span: Span,
+  params: Record<string, string | string[] | undefined>
+) => void;
+
+export interface TracingOptions {
+  accessToken: string;
+  realm?: string;
+  endpoint?: string;
+  serviceName: string;
+  // Tracing-specific configuration options:
+  captureHttpRequestUriParams: string[] | CaptureHttpUriParameters;
+  instrumentations: (Instrumentation | Instrumentation[])[];
+  propagatorFactory: PropagatorFactory;
+  serverTimingEnabled: boolean;
+  spanExporterFactory: SpanExporterFactory;
+  spanProcessorFactory: SpanProcessorFactory;
+  tracerConfig: NodeTracerConfig;
+}
+
+export type StartTracingOptions = Partial<TracingOptions> & {
+  resourceFactory?: ResourceFactory;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,20 +207,38 @@ export function parseLogLevel(value: string | undefined): DiagLogLevel {
   return DiagLogLevel.NONE;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function pick<T extends Record<string, any>, K extends string>(
-  obj: T,
-  keys: readonly K[]
-): { [P in keyof T as P extends K ? P : never]: T[P] } {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const result = {} as any;
-  for (let i = 0; i < keys.length; i++) {
-    const key = keys[i];
-    if (key in obj) {
-      result[key] = obj[key];
-    }
+function constructUrl(url: string): URL | undefined {
+  try {
+    return new URL(url);
+  } catch {
+    return undefined;
   }
-  return result;
+}
+
+export function ensureResourcePath(
+  url: string | undefined,
+  resourcePath: string
+): string | undefined {
+  if (url === undefined) {
+    return undefined;
+  }
+
+  const validUrl = constructUrl(url);
+
+  if (validUrl === undefined) {
+    diag.error(`Invalid URL: ${url}`);
+    return undefined;
+  }
+
+  if (validUrl.pathname === '/') {
+    diag.debug(
+      `Appending path ${resourcePath} to ${url} due to resource path not set.`
+    );
+    validUrl.pathname = resourcePath;
+    return validUrl.toString();
+  }
+
+  return url;
 }
 
 export function listEnvVars() {

--- a/test/common_options.test.ts
+++ b/test/common_options.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'assert';
+import { parseOptionsAndConfigureInstrumentations } from '../src/instrumentations';
+import { Resource } from '@opentelemetry/resources';
+
+describe('common options', () => {
+  it('passes resource creation function to signals', () => {
+    const opts = parseOptionsAndConfigureInstrumentations({
+      resource: (envResource) => {
+        return envResource.merge(
+          new Resource({
+            'test.attribute': 'foobar',
+          })
+        );
+      },
+    });
+
+    assert.strictEqual(
+      opts.tracingOptions.tracerConfig.resource?.attributes['test.attribute'],
+      'foobar'
+    );
+
+    assert.strictEqual(
+      opts.profilingOptions.resource.attributes['test.attribute'],
+      'foobar'
+    );
+
+    assert.strictEqual(
+      opts.profilingOptions.resource.attributes['test.attribute'],
+      'foobar'
+    );
+
+    assert.strictEqual(
+      opts.profilingOptions.resource.attributes['test.attribute'],
+      'foobar'
+    );
+  });
+
+  it('passes realm and accessToken to signals', () => {
+    const opts = parseOptionsAndConfigureInstrumentations({
+      realm: 'eu0',
+      accessToken: '123',
+    });
+
+    assert.strictEqual(opts.tracingOptions.realm, 'eu0');
+    assert.strictEqual(opts.tracingOptions.accessToken, '123');
+    assert.strictEqual(opts.metricsOptions.realm, 'eu0');
+    assert.strictEqual(opts.metricsOptions.accessToken, '123');
+  });
+
+  it('prefers signal specific options', () => {
+    const opts = parseOptionsAndConfigureInstrumentations({
+      realm: 'eu0',
+      accessToken: 'abc',
+      resource: () => new Resource({ test: 'common' }),
+      tracing: {
+        realm: 'us0',
+        accessToken: 'a',
+        resourceFactory: () => new Resource({ test: 'tracing' }),
+      },
+      metrics: {
+        realm: 'us1',
+        accessToken: 'b',
+        resourceFactory: () => new Resource({ test: 'metrics' }),
+      },
+      logging: {
+        resourceFactory: () => new Resource({ test: 'logging' }),
+      },
+      profiling: {
+        resourceFactory: () => new Resource({ test: 'profiling' }),
+      },
+    });
+
+    assert.strictEqual(opts.tracingOptions.realm, 'us0');
+    assert.strictEqual(opts.tracingOptions.accessToken, 'a');
+    assert.strictEqual(
+      opts.tracingOptions.tracerConfig.resource?.attributes['test'],
+      'tracing'
+    );
+
+    assert.strictEqual(opts.metricsOptions.realm, 'us1');
+    assert.strictEqual(opts.metricsOptions.accessToken, 'b');
+    assert.strictEqual(
+      opts.metricsOptions.resource.attributes['test'],
+      'metrics'
+    );
+
+    assert.strictEqual(
+      opts.loggingOptions.resource.attributes['test'],
+      'logging'
+    );
+
+    assert.strictEqual(
+      opts.profilingOptions.resource.attributes['test'],
+      'profiling'
+    );
+  });
+
+  it('sets the exporter endpoint resource paths automatically', () => {
+    const { tracingOptions, metricsOptions, loggingOptions, profilingOptions } =
+      parseOptionsAndConfigureInstrumentations({
+        endpoint: 'http://localhost:4318',
+      });
+
+    const traceUrl = tracingOptions.spanExporterFactory(tracingOptions)[0].url;
+    assert.strictEqual(traceUrl, 'http://localhost:4318/v1/traces');
+
+    const metricsUrl =
+      metricsOptions.metricReaderFactory(metricsOptions)[0]['_exporter'][
+        '_otlpExporter'
+      ].url;
+    assert.strictEqual(metricsUrl, 'http://localhost:4318/v1/metrics');
+
+    const logsUrl =
+      loggingOptions.logRecordProcessorFactory(loggingOptions)[0]['_exporter']
+        .url;
+    assert.strictEqual(logsUrl, 'http://localhost:4318/v1/logs');
+
+    const profilingUrl =
+      profilingOptions.exporterFactory(profilingOptions)[0]['_endpoint'];
+    assert.strictEqual(profilingUrl, 'http://localhost:4318/v1/logs');
+  });
+});

--- a/test/metrics.options.test.ts
+++ b/test/metrics.options.test.ts
@@ -180,7 +180,7 @@ describe('metrics options', () => {
       assert(exporter instanceof OTLPHttpProtoMetricExporter);
       assert.deepStrictEqual(
         exporter['_otlpExporter'].url,
-        'http://localhost:4320'
+        'http://localhost:4320/v1/metrics'
       );
     });
   });

--- a/test/metrics.options.test.ts
+++ b/test/metrics.options.test.ts
@@ -129,7 +129,6 @@ describe('metrics options', () => {
         exporter['_otlpExporter'].url,
         'https://ingest.us0.signalfx.com/v2/datapoint/otlp'
       );
-      //FIXME extract to calledWith utility method
       const msg = `OTLP metric exporter: defaulting protocol to 'http/protobuf' instead of 'grpc' due to realm being defined.`;
       assert.equal(logger.warn.mock.calls[0].arguments[0], msg);
     });

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -43,12 +43,11 @@ import { strict as assert } from 'assert';
 import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 import * as os from 'os';
 import * as instrumentations from '../src/instrumentations';
+import type { TracingOptions } from '../src/tracing';
 import {
   _setDefaultOptions,
-  allowedTracingOptions,
   defaultPropagatorFactory,
   defaultSpanProcessorFactory,
-  Options,
 } from '../src/tracing/options';
 import * as utils from './utils';
 import { ContainerDetector } from '@opentelemetry/resource-detector-container';
@@ -153,11 +152,6 @@ describe('options', () => {
           delete options.tracerConfig.resource?.attributes[processAttribute];
         });
 
-      assert.deepStrictEqual(
-        Object.keys(options).sort(),
-        allowedTracingOptions.sort()
-      );
-
       assert.deepStrictEqual(options.realm, undefined);
 
       /*
@@ -245,7 +239,6 @@ describe('options', () => {
       serverTimingEnabled: true,
       captureHttpRequestUriParams: [],
       instrumentations: [testInstrumentation],
-      resourceFactory,
       tracerConfig: {
         resource: new Resource({ attr1: 'value1' }),
         idGenerator: idGenerator,
@@ -515,7 +508,7 @@ function testSpanExporterFactory(): SpanExporter {
   return new InMemorySpanExporter();
 }
 
-function testSpanProcessorFactory(options: Options) {
+function testSpanProcessorFactory(options: TracingOptions) {
   const exporters = options.spanExporterFactory(options);
 
   if (Array.isArray(exporters)) {
@@ -525,6 +518,8 @@ function testSpanProcessorFactory(options: Options) {
   return new SimpleSpanProcessor(exporters);
 }
 
-function testPropagatorFactory(_options: Options): api.TextMapPropagator {
+function testPropagatorFactory(
+  _options: TracingOptions
+): api.TextMapPropagator {
   return new W3CBaggagePropagator();
 }

--- a/test/start.test.ts
+++ b/test/start.test.ts
@@ -49,7 +49,7 @@ const resource = Resource.empty();
 CONFIG.profiling = {
   callstackInterval,
   collectionDuration,
-  resource,
+  resourceFactory: () => resource,
 };
 
 const captureHttpRequestUriParams = 'captureHttpRequestUriParams';
@@ -127,8 +127,8 @@ describe('start', () => {
     };
   });
 
-  afterEach(() => {
-    stop();
+  afterEach(async () => {
+    await stop();
   });
 
   describe('toggling signals', () => {
@@ -287,13 +287,13 @@ describe('start', () => {
     it('does not enable diagnostic logging by default', () => {
       start();
       diag.info('42');
-      assert(logSpy.mock.callCount() === 0);
+      assert.strictEqual(logSpy.mock.callCount(), 0);
     });
 
     it('does not enable diagnostic logging via explicit config', () => {
       start({ logLevel: 'none' });
       diag.info('42');
-      assert(logSpy.mock.callCount() === 0);
+      assert.strictEqual(logSpy.mock.callCount(), 0);
     });
 
     it('is possible to enable diag logging via config', () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -23,6 +23,7 @@ import * as assert from 'assert';
 import * as util from 'util';
 import { Writable } from 'stream';
 import { context, trace } from '@opentelemetry/api';
+import { clearResource } from '../src/resource';
 
 const isConfigVarEntry = (key: string) => {
   const lowercased = key.toLowerCase();
@@ -43,6 +44,7 @@ const isConfigVarEntry = (key: string) => {
   between runs.
 */
 export const cleanEnvironment = () => {
+  clearResource();
   Object.keys(process.env)
     .filter(isConfigVarEntry)
     .forEach((key) => {


### PR DESCRIPTION
* `instrument` script now uses the `start` call instead of duplicating the logic.
* New option for `start`:`resource` - a method which is called with the detected environment resource. Users can return their own resource from this function, which gets passed to all signals (instead of doing it separately for all signals - where the API for it differed).
* New option for `start`: `realm` - when specified the `realm` is passed to the underlying signals. Only applicable for traces and metrics at the moment as logs and profiling data can't be sent directly over OTLP.
* Resource detection is now cached. Previously each signal called the same detection routines.
* When `http/protobuf` (the default setting) is enabled and `endpoint` option is set, signals now attach the resource path to the endpoint. E.g. `start({ endpoint: 'http://localhost:4318' });` means `/v1/traces`, `/v1/metrics` and `/v1/logs` resource paths are automatically appended.