### PR TITLE
chore: release v2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log - @splunk/otel
 
+## 2.15.0
+
+- Upgrade to OpenTelemetry `1.28.0` / `0.55.0`. [#987](https://github.com/signalfx/splunk-otel-js/pull/987)
+
 ## 2.14.0
 
 - Add Node.js 22 to prebuilds. [#963](https://github.com/signalfx/splunk-otel-js/pull/963)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '2.14.0';
+export const VERSION = '2.15.0';


### PR DESCRIPTION
- Upgrade to OpenTelemetry `1.28.0` / `0.55.0`. [#987](https://github.com/signalfx/splunk-otel-js/pull/987)