### PR TITLE
chore: release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 3.0.0
 
 > [!WARNING]
-> - Raise the minimum required Node.js version to 18. If Node <18 is a requirement, [2.x](https://github.com/signalfx/splunk-otel-js/tree/2.x) is still maintained and package versions 2.x can be used..
+>### Breaking changes
+>- Raise the minimum required Node.js version to 18. If Node <18 is a requirement, [2.x](https://github.com/signalfx/splunk-otel-js/tree/2.x) is still maintained and package versions 2.x can be used..
 >- Change the default OTLP protocol from `grpc` to `http/protobuf`. The default exporting endpoint has been changed from `http://localhost:4317` to `http://localhost:4318`. Signal specific URL paths are automatically added when choosing the endpoint, e.g. when `endpoint` is set to `http://collector:4318`, `/v1/traces` is added for traces.
 >- Change the default sampler from `parentbased_always_on` to `always_on`.
 >- Profiling configuration: `resource: Resource` field has been changed to `resourceFactory: (resource: Resource) => Resource` to bring it in line with tracing and metrics configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 ## 3.0.0
 
-> [!WARNING] Breaking changes
-
+> [!WARNING]
 > - Raise the minimum required Node.js version to 18. If Node <18 is a requirement, [2.x](https://github.com/signalfx/splunk-otel-js/tree/2.x) is still maintained and package versions 2.x can be used..
-> [!WARNING] Breaking change
 >- Change the default OTLP protocol from `grpc` to `http/protobuf`. The default exporting endpoint has been changed from `http://localhost:4317` to `http://localhost:4318`. Signal specific URL paths are automatically added when choosing the endpoint, e.g. when `endpoint` is set to `http://collector:4318`, `/v1/traces` is added for traces.
 >- Change the default sampler from `parentbased_always_on` to `always_on`.
 >- Profiling configuration: `resource: Resource` field has been changed to `resourceFactory: (resource: Resource) => Resource` to bring it in line with tracing and metrics configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @splunk/otel
 
-## 3.0.0-rc1
+## 3.0.0
 
 - Raise the minimum required Node.js version to 18. If Node <18 is a requirement, [2.x](https://github.com/signalfx/splunk-otel-js/tree/2.x) is still maintained and package versions 2.x can be used..
 - Change the default OTLP protocol from `grpc` to `http/protobuf`. The default exporting endpoint has been changed from `http://localhost:4317` to `http://localhost:4318`. Signal specific URL paths are automatically added when choosing the endpoint, e.g. when `endpoint` is set to `http://collector:4318`, `/v1/traces` is added for traces.
@@ -41,6 +41,10 @@
 - Fix logging of `service.name` attribute not set from each signal, when the service name is not set.
 - Add prebuilt binaries for Node.js 22 and 23.
 - Upgrade to OpenTelemetry `1.30.0` / `0.57.0`.
+
+## 3.0.0-rc1
+
+- Changes moved to 3.0.0.
 
 ## 2.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## 3.0.0
 
-- Raise the minimum required Node.js version to 18. If Node <18 is a requirement, [2.x](https://github.com/signalfx/splunk-otel-js/tree/2.x) is still maintained and package versions 2.x can be used..
-- Change the default OTLP protocol from `grpc` to `http/protobuf`. The default exporting endpoint has been changed from `http://localhost:4317` to `http://localhost:4318`. Signal specific URL paths are automatically added when choosing the endpoint, e.g. when `endpoint` is set to `http://collector:4318`, `/v1/traces` is added for traces.
-- Change the default sampler from `parentbased_always_on` to `always_on`.
+> [!WARNING] Breaking changes
+
+> - Raise the minimum required Node.js version to 18. If Node <18 is a requirement, [2.x](https://github.com/signalfx/splunk-otel-js/tree/2.x) is still maintained and package versions 2.x can be used..
+> [!WARNING] Breaking change
+>- Change the default OTLP protocol from `grpc` to `http/protobuf`. The default exporting endpoint has been changed from `http://localhost:4317` to `http://localhost:4318`. Signal specific URL paths are automatically added when choosing the endpoint, e.g. when `endpoint` is set to `http://collector:4318`, `/v1/traces` is added for traces.
+>- Change the default sampler from `parentbased_always_on` to `always_on`.
+>- Profiling configuration: `resource: Resource` field has been changed to `resourceFactory: (resource: Resource) => Resource` to bring it in line with tracing and metrics configuration.
+
 - Improve the start API to avoid duplicating parameters in the signal specific configuration.
   * Add `resource` field - a function which can be used to overwrite or add additional parameters to the resource detected from the environment.
 
@@ -35,7 +40,6 @@
     ```
 
   Signal specific options can still be used and take preference over the shared configuration options.
-- Profiling configuration: `resource: Resource` field has been changed to `resourceFactory: (resource: Resource) => Resource` to bring it in line with tracing and metrics configuration.
 - `splunk.distro.version` (automatically added resource attribute) has been removed and is replaced with `telemetry.distro.version` and `telemetry.distro.name`.
 - `SPLUNK_METRICS_ENDPOINT` environment variable has been removed. Use the OpenTelemetry specific `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` instead.
 - Fix logging of `service.name` attribute not set from each signal, when the service name is not set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > [!WARNING]
 >### Breaking changes
->- Raise the minimum required Node.js version to 18. If Node <18 is a requirement, [2.x](https://github.com/signalfx/splunk-otel-js/tree/2.x) is still maintained and package versions 2.x can be used..
+>- Raise the minimum required Node.js version to 18. If Node <18 is a requirement, [2.x](https://github.com/signalfx/splunk-otel-js/tree/2.x) is still maintained and package versions 2.x can be used.
 >- Change the default OTLP protocol from `grpc` to `http/protobuf`. The default exporting endpoint has been changed from `http://localhost:4317` to `http://localhost:4318`. Signal specific URL paths are automatically added when choosing the endpoint, e.g. when `endpoint` is set to `http://collector:4318`, `/v1/traces` is added for traces.
 >- Change the default sampler from `parentbased_always_on` to `always_on`.
 >- Profiling configuration: `resource: Resource` field has been changed to `resourceFactory: (resource: Resource) => Resource` to bring it in line with tracing and metrics configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "3.0.0-rc1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "3.0.0-rc1",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "3.0.0-rc1",
+  "version": "3.0.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '3.0.0-rc1';
+export const VERSION = '3.0.0';


### PR DESCRIPTION
- Raise the minimum required Node.js version to 18. If Node <18 is a requirement, [2.x](https://github.com/signalfx/splunk-otel-js/tree/2.x) is still maintained and package versions 2.x can be used..
- Change the default OTLP protocol from `grpc` to `http/protobuf`. The default exporting endpoint has been changed from `http://localhost:4317` to `http://localhost:4318`. Signal specific URL paths are automatically added when choosing the endpoint, e.g. when `endpoint` is set to `http://collector:4318`, `/v1/traces` is added for traces.
- Change the default sampler from `parentbased_always_on` to `always_on`.
- Improve the start API to avoid duplicating parameters in the signal specific configuration.
  * Add `resource` field - a function which can be used to overwrite or add additional parameters to the resource detected from the environment.
    ```ts
    import { start } from '@splunk/otel';
    import { Resource } from '@opentelemetry/resources';
    start({
      serviceName: 'example',
      resource: (detectedResource) => {
        return detectedResource.merge(new Resource({ 'service.version': '0.2.0' }));
      },
    });
    ```
  * Add `realm` field. When set passes the access token and realm to signals.
    ```ts
    import { start } from '@splunk/otel';
    start({
      serviceName: 'example',
      realm: 'us0',
      accessToken: '<token>'
    });
    // Traces and metrics are now sent to the us0 backend.
    ```
  Signal specific options can still be used and take preference over the shared configuration options.
- Profiling configuration: `resource: Resource` field has been changed to `resourceFactory: (resource: Resource) => Resource` to bring it in line with tracing and metrics configuration.
- `splunk.distro.version` (automatically added resource attribute) has been removed and is replaced with `telemetry.distro.version` and `telemetry.distro.name`.
- `SPLUNK_METRICS_ENDPOINT` environment variable has been removed. Use the OpenTelemetry specific `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` instead.
- Fix logging of `service.name` attribute not set from each signal, when the service name is not set.
- Add prebuilt binaries for Node.js 22 and 23.
- Upgrade to OpenTelemetry `1.30.0` / `0.57.0`.