### PR TITLE
Add neo4j driver instrumentation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,23 +37,10 @@ module.exports = {
       "arrowParens": "always"
     }],
     "n/no-deprecated-api": ["warn"],
-    "header/header": [2, "block", [
-        "",
-        " * Copyright Splunk Inc.",
-        " *",
-        " * Licensed under the Apache License, Version 2.0 (the \"License\");",
-        " * you may not use this file except in compliance with the License.",
-        " * You may obtain a copy of the License at",
-        " *",
-        " *     http://www.apache.org/licenses/LICENSE-2.0",
-        " *",
-        " * Unless required by applicable law or agreed to in writing, software",
-        " * distributed under the License is distributed on an \"AS IS\" BASIS,",
-        " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
-        " * See the License for the specific language governing permissions and",
-        " * limitations under the License.",
-        " "
-    ]]
+    "header/header": ["error", "block", [{
+      pattern: / \* Copyright Splunk Inc\.(, .+)*[\r\n]+ \*[\r\n+] \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\);[\r\n]+ \* you may not use this file except in compliance with the License\.[\r\n]+ \* You may obtain a copy of the License at[\r\n]+ \*[\r\n]+ \*     http:\/\/www\.apache\.org\/licenses\/LICENSE-2\.0[\r\n]+ \*[\r\n]+ \* Unless required by applicable law or agreed to in writing, software[\r\n]+ \* distributed under the License is distributed on an \"AS IS\" BASIS,[\r\n]+ \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.[\r\n]+ \* See the License for the specific language governing permissions and[\r\n]+ \* limitations under the License\./gm,
+      template: `\n * Copyright Splunk Inc.\n *\n * Licensed under the Apache License, Version 2.0 (the "License");\n * you may not use this file except in compliance with the License.\n * You may obtain a copy of the License at\n *\n *     http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required by applicable law or agreed to in writing, software\n * distributed under the License is distributed on an "AS IS" BASIS,\n * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n * See the License for the specific language governing permissions and\n * limitations under the License.\n `
+    }]]
   },
   overrides: [
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
             nodejs: '23.0.0'
     services:
       neo4j:
-        image: neo4j:4.4.42
+        image: ${{ (matrix.os == 'ubuntu-latest') && 'neo4j:4.4.42' || '' }}
         ports:
           - 11011:7687
         env:
@@ -166,6 +166,8 @@ jobs:
         run: npm ci
       - name: Test
         run: npm run test
+        env:
+          NEO4J_TEST_WITH_LOCAL: true
       - name: Report Coverage
         if: ${{matrix.nodejs == '16' && matrix.os == 'ubuntu-latest'}}
         uses: codecov/codecov-action@v3
@@ -174,13 +176,6 @@ jobs:
 
   unit-tests-arm64:
     runs-on: ${{ matrix.os }}
-    services:
-      neo4j:
-        image: neo4j:4.4.42
-        ports:
-          - 11011:7687
-        env:
-          NEO4J_AUTH: neo4j/test_pw
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Test
         run: npm run test
         env:
-          NEO4J_TEST_WITH_LOCAL: true
+          NEO4J_TEST_WITH_LOCAL: ${{ (matrix.os == 'ubuntu-latest') && 'true' || 'false' }}
       - name: Report Coverage
         if: ${{matrix.nodejs == '16' && matrix.os == 'ubuntu-latest'}}
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           path: allprebuilds
       - name: copy prebuilds
         run: |
-          mkdir -p prebuilds    
+          mkdir -p prebuilds
           cp -r allprebuilds/prebuilds-linux-arm64-*/* prebuilds
           cp -r allprebuilds/prebuilds-linux-*/* prebuilds
           cp -r allprebuilds/prebuilds-Windows-*/* prebuilds
@@ -146,6 +146,13 @@ jobs:
             nodejs: '22.10.0'
           - os: 'windows-2019'
             nodejs: '23.0.0'
+    services:
+      neo4j:
+        image: neo4j:4.4.42
+        ports:
+          - 11011:7687
+        env:
+          NEO4J_AUTH: neo4j/test_pw
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -167,6 +174,13 @@ jobs:
 
   unit-tests-arm64:
     runs-on: ${{ matrix.os }}
+    services:
+      neo4j:
+        image: neo4j:4.4.42
+        ports:
+          - 11011:7687
+        env:
+          NEO4J_AUTH: neo4j/test_pw
     strategy:
       fail-fast: false
       matrix:

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk's Distribution of OpenTelemetry for Node.js
-Copyright 2024 Splunk Inc.
+Copyright 2025 Splunk Inc.
 
 Parts of the library, such as elasticsearch, sequelize, neo4j and typeorm instrumentations,
 are copied and derived from instrumentations (https://github.com/aspecto-io/opentelemetry-ext-js) created by Aspecto

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 Splunk's Distribution of OpenTelemetry for Node.js
-Copyright 2023 Splunk Inc.
+Copyright 2024 Splunk Inc.
 
-Parts of the library, such as elasticsearch, sequelize and typeorm instrumentations,
+Parts of the library, such as elasticsearch, sequelize, neo4j and typeorm instrumentations,
 are copied and derived from instrumentations (https://github.com/aspecto-io/opentelemetry-ext-js) created by Aspecto
 (https://www.aspecto.io/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "gts": "^6.0.2",
         "mysql2": "^3.10.2",
+        "neo4j-driver": "4.4.10",
         "nock": "^13.5.6",
         "nyc": "^17.1.0",
         "octokit": "^3.1.2",
@@ -7004,6 +7005,63 @@
         "ncp": "bin/ncp"
       }
     },
+    "node_modules/neo4j-driver": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-4.4.10.tgz",
+      "integrity": "sha512-FLAytWQbR1CkRFBlmt5N5+PDuKQpSARQXT7F+LFJPar3CKjMrP4VNT5UKfkl0tVc5QSrTxF/Aw2YGBzhs1kyCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "neo4j-driver-bolt-connection": "^4.4.10",
+        "neo4j-driver-core": "^4.4.10",
+        "rxjs": "^6.6.3"
+      }
+    },
+    "node_modules/neo4j-driver-bolt-connection": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-4.4.11.tgz",
+      "integrity": "sha512-2sCgx3Lpg7fnYAU/kb9wOKY8ResUeur88MhLNUWyINxa+CMP7aB+t70zBcOlJ7hcCf6ghEiz6ZXhd9WikGW9bA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "neo4j-driver-core": "4.4.11",
+        "string_decoder": "^1.3.0"
+      }
+    },
+    "node_modules/neo4j-driver-bolt-connection/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/neo4j-driver-core": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-4.4.11.tgz",
+      "integrity": "sha512-7+7Ue9RNsg5TAwkPvl4/st2ZdktN3qH8A/MYmJkZ6Ait8MuXP8ppTvZ3ugPxbrSOJEwvZYpKqV+FNZ17mOSfcQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/nock": {
       "version": "13.5.6",
       "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
@@ -7737,35 +7795,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/pino-abstract-transport/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/pino-abstract-transport/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/pino-std-serializers": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
@@ -8465,9 +8494,24 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-json-stringify": {
       "version": "1.2.0",
@@ -8752,11 +8796,12 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -14622,6 +14667,47 @@
       "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
       "dev": true
     },
+    "neo4j-driver": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-4.4.10.tgz",
+      "integrity": "sha512-FLAytWQbR1CkRFBlmt5N5+PDuKQpSARQXT7F+LFJPar3CKjMrP4VNT5UKfkl0tVc5QSrTxF/Aw2YGBzhs1kyCA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "neo4j-driver-bolt-connection": "^4.4.10",
+        "neo4j-driver-core": "^4.4.10",
+        "rxjs": "^6.6.3"
+      }
+    },
+    "neo4j-driver-bolt-connection": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-4.4.11.tgz",
+      "integrity": "sha512-2sCgx3Lpg7fnYAU/kb9wOKY8ResUeur88MhLNUWyINxa+CMP7aB+t70zBcOlJ7hcCf6ghEiz6ZXhd9WikGW9bA==",
+      "dev": true,
+      "requires": {
+        "buffer": "^6.0.3",
+        "neo4j-driver-core": "4.4.11",
+        "string_decoder": "^1.3.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
+      }
+    },
+    "neo4j-driver-core": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-4.4.11.tgz",
+      "integrity": "sha512-7+7Ue9RNsg5TAwkPvl4/st2ZdktN3qH8A/MYmJkZ6Ait8MuXP8ppTvZ3ugPxbrSOJEwvZYpKqV+FNZ17mOSfcQ==",
+      "dev": true
+    },
     "nock": {
       "version": "13.5.6",
       "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
@@ -15177,21 +15263,6 @@
             "process": "^0.11.10",
             "string_decoder": "^1.3.0"
           }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
         }
       }
     },
@@ -15697,9 +15768,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-json-stringify": {
       "version": "1.2.0",
@@ -15911,11 +15982,11 @@
       "dev": true
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "string-width": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "gts": "^6.0.2",
         "mysql2": "^3.10.2",
-        "neo4j-driver": "4.4.10",
+        "neo4j-driver": "5.28.1",
         "nock": "^13.5.6",
         "nyc": "^17.1.0",
         "octokit": "^3.1.2",
@@ -7006,27 +7006,26 @@
       }
     },
     "node_modules/neo4j-driver": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-4.4.10.tgz",
-      "integrity": "sha512-FLAytWQbR1CkRFBlmt5N5+PDuKQpSARQXT7F+LFJPar3CKjMrP4VNT5UKfkl0tVc5QSrTxF/Aw2YGBzhs1kyCA==",
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-5.28.1.tgz",
+      "integrity": "sha512-jbyBwyM0a3RLGcP43q3hIxPUPxA+1bE04RovOKdNAS42EtBMVCKcPSeOvWiHxgXp1ZFd0a8XqK+7LtguInOLUg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "neo4j-driver-bolt-connection": "^4.4.10",
-        "neo4j-driver-core": "^4.4.10",
-        "rxjs": "^6.6.3"
+        "neo4j-driver-bolt-connection": "5.28.1",
+        "neo4j-driver-core": "5.28.1",
+        "rxjs": "^7.8.1"
       }
     },
     "node_modules/neo4j-driver-bolt-connection": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-4.4.11.tgz",
-      "integrity": "sha512-2sCgx3Lpg7fnYAU/kb9wOKY8ResUeur88MhLNUWyINxa+CMP7aB+t70zBcOlJ7hcCf6ghEiz6ZXhd9WikGW9bA==",
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-5.28.1.tgz",
+      "integrity": "sha512-nY8GBhjOW7J0rDtpiyJn6kFdk2OiNVZZhZrO8//mwNXnf5VQJ6HqZQTDthH/9pEaX0Jvbastz1xU7ZL8xzqY0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "^6.0.3",
-        "neo4j-driver-core": "4.4.11",
+        "neo4j-driver-core": "5.28.1",
         "string_decoder": "^1.3.0"
       }
     },
@@ -7056,11 +7055,28 @@
       }
     },
     "node_modules/neo4j-driver-core": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-4.4.11.tgz",
-      "integrity": "sha512-7+7Ue9RNsg5TAwkPvl4/st2ZdktN3qH8A/MYmJkZ6Ait8MuXP8ppTvZ3ugPxbrSOJEwvZYpKqV+FNZ17mOSfcQ==",
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-5.28.1.tgz",
+      "integrity": "sha512-14vN8TlxC0JvJYfjWic5PwjsZ38loQLOKFTXwk4fWLTbCk6VhrhubB2Jsy9Rz+gM6PtTor4+6ClBEFDp1q/c8g==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/neo4j-driver/node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/neo4j-driver/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/nock": {
       "version": "13.5.6",
@@ -14668,25 +14684,41 @@
       "dev": true
     },
     "neo4j-driver": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-4.4.10.tgz",
-      "integrity": "sha512-FLAytWQbR1CkRFBlmt5N5+PDuKQpSARQXT7F+LFJPar3CKjMrP4VNT5UKfkl0tVc5QSrTxF/Aw2YGBzhs1kyCA==",
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-5.28.1.tgz",
+      "integrity": "sha512-jbyBwyM0a3RLGcP43q3hIxPUPxA+1bE04RovOKdNAS42EtBMVCKcPSeOvWiHxgXp1ZFd0a8XqK+7LtguInOLUg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.5.5",
-        "neo4j-driver-bolt-connection": "^4.4.10",
-        "neo4j-driver-core": "^4.4.10",
-        "rxjs": "^6.6.3"
+        "neo4j-driver-bolt-connection": "5.28.1",
+        "neo4j-driver-core": "5.28.1",
+        "rxjs": "^7.8.1"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "7.8.2",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+          "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+          "dev": true
+        }
       }
     },
     "neo4j-driver-bolt-connection": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-4.4.11.tgz",
-      "integrity": "sha512-2sCgx3Lpg7fnYAU/kb9wOKY8ResUeur88MhLNUWyINxa+CMP7aB+t70zBcOlJ7hcCf6ghEiz6ZXhd9WikGW9bA==",
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-5.28.1.tgz",
+      "integrity": "sha512-nY8GBhjOW7J0rDtpiyJn6kFdk2OiNVZZhZrO8//mwNXnf5VQJ6HqZQTDthH/9pEaX0Jvbastz1xU7ZL8xzqY0w==",
       "dev": true,
       "requires": {
         "buffer": "^6.0.3",
-        "neo4j-driver-core": "4.4.11",
+        "neo4j-driver-core": "5.28.1",
         "string_decoder": "^1.3.0"
       },
       "dependencies": {
@@ -14703,9 +14735,9 @@
       }
     },
     "neo4j-driver-core": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-4.4.11.tgz",
-      "integrity": "sha512-7+7Ue9RNsg5TAwkPvl4/st2ZdktN3qH8A/MYmJkZ6Ait8MuXP8ppTvZ3ugPxbrSOJEwvZYpKqV+FNZ17mOSfcQ==",
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-5.28.1.tgz",
+      "integrity": "sha512-14vN8TlxC0JvJYfjWic5PwjsZ38loQLOKFTXwk4fWLTbCk6VhrhubB2Jsy9Rz+gM6PtTor4+6ClBEFDp1q/c8g==",
       "dev": true
     },
     "nock": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "gts": "^6.0.2",
     "mysql2": "^3.10.2",
-    "neo4j-driver": "4.4.10",
+    "neo4j-driver": "5.28.1",
     "nock": "^13.5.6",
     "nyc": "^17.1.0",
     "octokit": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "gts": "^6.0.2",
     "mysql2": "^3.10.2",
+    "neo4j-driver": "4.4.10",
     "nock": "^13.5.6",
     "nyc": "^17.1.0",
     "octokit": "^3.1.2",

--- a/src/instrumentations/external/neo4j/index.ts
+++ b/src/instrumentations/external/neo4j/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { Neo4jInstrumentation } from './neo4j';
+export { Neo4jInstrumentationConfig } from './types';

--- a/src/instrumentations/external/neo4j/index.ts
+++ b/src/instrumentations/external/neo4j/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright Splunk Inc.
+ * Copyright Splunk Inc., Aspecto
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/instrumentations/external/neo4j/neo4j.ts
+++ b/src/instrumentations/external/neo4j/neo4j.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  SpanStatusCode,
+  diag,
+  trace,
+  context,
+  SpanKind,
+} from '@opentelemetry/api';
+import {
+  SEMATTRS_DB_NAME,
+  SEMATTRS_DB_OPERATION,
+  SEMATTRS_DB_STATEMENT,
+  SEMATTRS_DB_SYSTEM,
+} from '@opentelemetry/semantic-conventions';
+import { VERSION } from '../../../version';
+import type * as neo4j from 'neo4j-driver';
+import {
+  InstrumentationBase,
+  InstrumentationModuleDefinition,
+  InstrumentationNodeModuleFile,
+  InstrumentationNodeModuleDefinition,
+  isWrapped,
+  safeExecuteInTheMiddle,
+} from '@opentelemetry/instrumentation';
+import { Neo4jInstrumentationConfig } from './types';
+import { getAttributesFromNeo4jSession } from './utils';
+
+type RunArgs =
+  | Parameters<neo4j.Session['run']>
+  | Parameters<neo4j.Transaction['run']>;
+
+export class Neo4jInstrumentation extends InstrumentationBase<Neo4jInstrumentationConfig> {
+  constructor(config: Neo4jInstrumentationConfig = {}) {
+    super('splunk-opentelemetry-instrumentation-neo4j', VERSION, config);
+  }
+
+  protected init(): InstrumentationModuleDefinition[] {
+    return [
+      this.getModuleDefinition('neo4j-driver-core', ['>=4.3.0 <5']),
+      this.getModuleDefinition('neo4j-driver', ['>=4.0.0 <4.3.0']),
+    ];
+  }
+
+  private getModuleDefinition(
+    name: string,
+    supportedVersions: string[]
+  ): InstrumentationNodeModuleDefinition {
+    const apiModuleFiles = ['session', 'transaction'].map(
+      (file) =>
+        new InstrumentationNodeModuleFile(
+          `${name}/lib/${file}.js`,
+          supportedVersions,
+          (moduleExports) => {
+            if (isWrapped(moduleExports.default.prototype.run)) {
+              this._unwrap(moduleExports.default.prototype, 'run');
+            }
+
+            this.patchSessionOrTransaction(moduleExports);
+
+            return moduleExports;
+          },
+          (moduleExports) => {
+            if (isWrapped(moduleExports.default.prototype.run)) {
+              this._unwrap(moduleExports.default.prototype, 'run');
+            }
+          }
+        )
+    );
+
+    const module = new InstrumentationNodeModuleDefinition(
+      name,
+      supportedVersions,
+      undefined,
+      undefined,
+      apiModuleFiles
+    );
+
+    return module;
+  }
+
+  private patchSessionOrTransaction(fileExport: {
+    default: () => neo4j.Session | neo4j.Transaction;
+  }) {
+    const self = this;
+    this._wrap(
+      fileExport.default.prototype,
+      'run',
+      (originalRun: neo4j.Session['run']) => {
+        return function (this: unknown, ...args: RunArgs) {
+          if (self.getConfig().ignoreOrphanedSpans) {
+            if (!trace.getSpan(context.active())) {
+              return originalRun.apply(this, args);
+            }
+          }
+
+          const connectionAttributes = getAttributesFromNeo4jSession(this);
+          const query = args[0] as string;
+          const operation = query.trim().split(/\s+/)[0];
+          const span = self.tracer.startSpan(
+            `${operation} ${connectionAttributes[SEMATTRS_DB_NAME]}`,
+            {
+              attributes: {
+                ...connectionAttributes,
+                [SEMATTRS_DB_SYSTEM]: 'neo4j',
+                [SEMATTRS_DB_OPERATION]: operation,
+                [SEMATTRS_DB_STATEMENT]: query,
+              },
+              kind: SpanKind.CLIENT,
+            }
+          );
+          let spanEnded = false;
+          const endSpan = () => {
+            if (spanEnded) return;
+
+            span.end();
+            spanEnded = true;
+          };
+
+          const response: neo4j.Result = originalRun.apply(this, args);
+
+          const originalSubscribe = response.subscribe;
+          response.subscribe = function (observer) {
+            const records: neo4j.Record[] = [];
+
+            return originalSubscribe.call(this, {
+              ...observer,
+              onKeys: function (
+                this: unknown,
+                ...args: Parameters<NonNullable<neo4j.ResultObserver['onKeys']>>
+              ) {
+                if (!observer.onKeys) return;
+                if (!observer.onCompleted) {
+                  endSpan();
+                }
+                return observer.onKeys.apply(this, args);
+              },
+              onNext: function (
+                this: unknown,
+                ...args: Parameters<NonNullable<neo4j.ResultObserver['onNext']>>
+              ) {
+                if (self.getConfig().responseHook) {
+                  records.push(args[0]);
+                }
+                if (observer.onNext) return observer.onNext.apply(this, args);
+              },
+              onCompleted: function (
+                this: unknown,
+                ...args: Parameters<
+                  NonNullable<neo4j.ResultObserver['onCompleted']>
+                >
+              ) {
+                const responseHook = self.getConfig().responseHook;
+                if (responseHook) {
+                  safeExecuteInTheMiddle(
+                    () =>
+                      responseHook(span, {
+                        records: records,
+                        summary: args[0],
+                      }),
+                    (e) => {
+                      if (e) {
+                        diag.error('responseHook error', e);
+                      }
+                    },
+                    true
+                  );
+                }
+                endSpan();
+                if (observer.onCompleted)
+                  return observer.onCompleted.apply(this, args);
+              },
+              onError: function (
+                this: unknown,
+                ...args: Parameters<
+                  NonNullable<neo4j.ResultObserver['onError']>
+                >
+              ) {
+                const err = args[0];
+                span.recordException(err);
+                span.setStatus({
+                  code: SpanStatusCode.ERROR,
+                  message: err.message,
+                });
+                endSpan();
+                if (observer.onError) return observer.onError.apply(this, args);
+              },
+            });
+          };
+
+          return response;
+        };
+      }
+    );
+    return fileExport;
+  }
+}

--- a/src/instrumentations/external/neo4j/neo4j.ts
+++ b/src/instrumentations/external/neo4j/neo4j.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright Splunk Inc.
+ * Copyright Splunk Inc., Aspecto
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/instrumentations/external/neo4j/neo4j.ts
+++ b/src/instrumentations/external/neo4j/neo4j.ts
@@ -21,11 +21,11 @@ import {
   SpanKind,
 } from '@opentelemetry/api';
 import {
-  SEMATTRS_DB_NAME,
-  SEMATTRS_DB_OPERATION,
-  SEMATTRS_DB_STATEMENT,
-  SEMATTRS_DB_SYSTEM,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_DB_NAME,
+  ATTR_DB_OPERATION,
+  ATTR_DB_STATEMENT,
+  ATTR_DB_SYSTEM,
+} from './semconv';
 import { VERSION } from '../../../version';
 import type * as neo4j from 'neo4j-driver';
 import {
@@ -111,13 +111,13 @@ export class Neo4jInstrumentation extends InstrumentationBase<Neo4jInstrumentati
           const query = args[0] as string;
           const operation = query.trim().split(/\s+/)[0];
           const span = self.tracer.startSpan(
-            `${operation} ${connectionAttributes[SEMATTRS_DB_NAME]}`,
+            `${operation} ${connectionAttributes[ATTR_DB_NAME]}`,
             {
               attributes: {
                 ...connectionAttributes,
-                [SEMATTRS_DB_SYSTEM]: 'neo4j',
-                [SEMATTRS_DB_OPERATION]: operation,
-                [SEMATTRS_DB_STATEMENT]: query,
+                [ATTR_DB_SYSTEM]: 'neo4j',
+                [ATTR_DB_OPERATION]: operation,
+                [ATTR_DB_STATEMENT]: query,
               },
               kind: SpanKind.CLIENT,
             }

--- a/src/instrumentations/external/neo4j/semconv.ts
+++ b/src/instrumentations/external/neo4j/semconv.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const ATTR_DB_NAME = 'db.name' as const;
+export const ATTR_DB_USER = 'db.user' as const;
+export const ATTR_NET_PEER_NAME = 'net.peer.name' as const;
+export const ATTR_NET_PEER_PORT = 'net.peer.port' as const;
+export const ATTR_NET_TRANSPORT = 'net.transport' as const;
+export const ATTR_DB_OPERATION = 'db.operation' as const;
+export const ATTR_DB_STATEMENT = 'db.statement' as const;
+export const ATTR_DB_SYSTEM = 'db.system' as const;

--- a/src/instrumentations/external/neo4j/types.ts
+++ b/src/instrumentations/external/neo4j/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright Splunk Inc.
+ * Copyright Splunk Inc., Aspecto
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/instrumentations/external/neo4j/types.ts
+++ b/src/instrumentations/external/neo4j/types.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Span } from '@opentelemetry/api';
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import type { QueryResult } from 'neo4j-driver';
+
+export type Neo4jResponseCustomAttributesFunction = (
+  span: Span,
+  response: QueryResult
+) => void;
+
+export interface Neo4jInstrumentationConfig extends InstrumentationConfig {
+  /** hook for adding custom attributes using the response payload */
+  responseHook?: Neo4jResponseCustomAttributesFunction;
+  /** Set to true if you only want to trace operation which has parent spans */
+  ignoreOrphanedSpans?: boolean;
+}

--- a/src/instrumentations/external/neo4j/utils.ts
+++ b/src/instrumentations/external/neo4j/utils.ts
@@ -14,12 +14,22 @@
  * limitations under the License.
  */
 import {
-  SEMATTRS_DB_NAME,
-  SEMATTRS_DB_USER,
-  SEMATTRS_NET_PEER_NAME,
-  SEMATTRS_NET_PEER_PORT,
-  SEMATTRS_NET_TRANSPORT,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_DB_NAME,
+  ATTR_DB_USER,
+  ATTR_NET_PEER_NAME,
+  ATTR_NET_PEER_PORT,
+  ATTR_NET_TRANSPORT,
+} from './semconv';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getAuth(connectionProvider: any) {
+  if (connectionProvider._authenticationProvider) {
+    return connectionProvider._authenticationProvider._authTokenManager
+      ?._authToken;
+  }
+
+  return connectionProvider._authToken;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getAttributesFromNeo4jSession(session: any) {
@@ -33,20 +43,21 @@ export function getAttributesFromNeo4jSession(session: any) {
 
   // seedRouter is used when connecting to a url that starts with "neo4j", usually aura
   const address = connectionProvider._address ?? connectionProvider._seedRouter;
-  const auth = connectionProvider._authToken;
+  const auth = getAuth(connectionProvider);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const attributes: Record<string, any> = {
-    [SEMATTRS_NET_TRANSPORT]: 'IP.TCP',
+    [ATTR_NET_TRANSPORT]: 'IP.TCP',
     // "neo4j" is the default database name. When used, "session._database" is an empty string
-    [SEMATTRS_DB_NAME]: session._database ? session._database : 'neo4j',
+    [ATTR_DB_NAME]: session._database ? session._database : 'neo4j',
   };
   if (address) {
-    attributes[SEMATTRS_NET_PEER_NAME] = address._host;
-    attributes[SEMATTRS_NET_PEER_PORT] = address._port;
+    attributes[ATTR_NET_PEER_NAME] = address._host;
+    attributes[ATTR_NET_PEER_PORT] = address._port;
   }
+
   if (auth?.principal) {
-    attributes[SEMATTRS_DB_USER] = auth.principal;
+    attributes[ATTR_DB_USER] = auth.principal;
   }
   return attributes;
 }

--- a/src/instrumentations/external/neo4j/utils.ts
+++ b/src/instrumentations/external/neo4j/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright Splunk Inc.
+ * Copyright Splunk Inc., Aspecto
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/instrumentations/external/neo4j/utils.ts
+++ b/src/instrumentations/external/neo4j/utils.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  SEMATTRS_DB_NAME,
+  SEMATTRS_DB_USER,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
+  SEMATTRS_NET_TRANSPORT,
+} from '@opentelemetry/semantic-conventions';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getAttributesFromNeo4jSession(session: any) {
+  const connectionHolder =
+    (session._mode === 'WRITE'
+      ? session._writeConnectionHolder
+      : session._readConnectionHolder) ??
+    session._connectionHolder ??
+    {};
+  const connectionProvider = connectionHolder._connectionProvider ?? {};
+
+  // seedRouter is used when connecting to a url that starts with "neo4j", usually aura
+  const address = connectionProvider._address ?? connectionProvider._seedRouter;
+  const auth = connectionProvider._authToken;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const attributes: Record<string, any> = {
+    [SEMATTRS_NET_TRANSPORT]: 'IP.TCP',
+    // "neo4j" is the default database name. When used, "session._database" is an empty string
+    [SEMATTRS_DB_NAME]: session._database ? session._database : 'neo4j',
+  };
+  if (address) {
+    attributes[SEMATTRS_NET_PEER_NAME] = address._host;
+    attributes[SEMATTRS_NET_PEER_PORT] = address._port;
+  }
+  if (auth?.principal) {
+    attributes[SEMATTRS_DB_USER] = auth.principal;
+  }
+  return attributes;
+}

--- a/test/instrumentation/external/neo4j/neo4j.test.ts
+++ b/test/instrumentation/external/neo4j/neo4j.test.ts
@@ -67,7 +67,7 @@ describe('neo4j instrumentation', { skip: !shouldTest }, () => {
 
     if (testWithDocker) {
       startContainer(
-        'docker run --rm -d --name splunk-otel-neo4j -p 11011:7687 -e NEO4J_AUTH=neo4j/test_pw neo4j:4.4.34'
+        'docker run --rm -d --name splunk-otel-neo4j -p 11011:7687 -e NEO4J_AUTH=neo4j/test_pw neo4j:4.4.42'
       );
     }
 
@@ -97,11 +97,11 @@ describe('neo4j instrumentation', { skip: !shouldTest }, () => {
   });
 
   after(async () => {
-    await driver.close();
-
     if (testWithDocker) {
       stopContainer('splunk-otel-neo4j');
     }
+
+    await driver.close();
   });
 
   beforeEach(async () => {

--- a/test/instrumentation/external/neo4j/neo4j.test.ts
+++ b/test/instrumentation/external/neo4j/neo4j.test.ts
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 import { strict as assert } from 'assert';
-import {
-  after,
-  afterEach,
-  before,
-  beforeEach,
-  describe,
-  it,
-  suite,
-} from 'node:test';
+import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 import {
   context,
   ROOT_CONTEXT,
@@ -60,11 +52,6 @@ describe('neo4j instrumentation', { skip: !shouldTest }, () => {
   };
 
   before(async () => {
-    if (!shouldTest) {
-      suite.skip();
-      return;
-    }
-
     if (testWithDocker) {
       startContainer(
         'docker run --rm -d --name splunk-otel-neo4j -p 11011:7687 -e NEO4J_AUTH=neo4j/test_pw neo4j:4.4.42'

--- a/test/instrumentation/external/neo4j/neo4j.test.ts
+++ b/test/instrumentation/external/neo4j/neo4j.test.ts
@@ -39,7 +39,7 @@ import neo4j, { Driver } from 'neo4j-driver';
 import { normalizeResponse, assertSpan } from './utils';
 
 const testWithDocker = process.env.NEO4J_TEST_WITH_DOCKER !== undefined;
-const testWithLocalNeo4j = process.env.NEO4J_TEST_WITH_LOCAL !== undefined;
+const testWithLocalNeo4j = process.env.NEO4J_TEST_WITH_LOCAL === 'true';
 const shouldTest = testWithDocker || testWithLocalNeo4j;
 
 describe('neo4j instrumentation', { skip: !shouldTest }, () => {

--- a/test/instrumentation/external/neo4j/neo4j.test.ts
+++ b/test/instrumentation/external/neo4j/neo4j.test.ts
@@ -1,0 +1,562 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { strict as assert } from 'assert';
+import {
+  after,
+  afterEach,
+  before,
+  beforeEach,
+  describe,
+  it,
+  suite,
+} from 'node:test';
+import {
+  context,
+  ROOT_CONTEXT,
+  SpanStatusCode,
+  trace,
+} from '@opentelemetry/api';
+import { Neo4jInstrumentation } from '../../../../src/instrumentations/external/neo4j';
+import {
+  SEMATTRS_DB_OPERATION,
+  SEMATTRS_DB_STATEMENT,
+} from '@opentelemetry/semantic-conventions';
+import { map, mergeMap } from 'rxjs/operators';
+// eslint-disable-next-line n/no-extraneous-import
+import { concat } from 'rxjs';
+import { setInstrumentation, getTestSpans, provider, exporter } from '../setup';
+import { startContainer, stopContainer } from '../../../utils';
+
+const instrumentation = new Neo4jInstrumentation();
+provider.register();
+
+import neo4j, { Driver } from 'neo4j-driver';
+import { normalizeResponse, assertSpan } from './utils';
+
+const testWithDocker = process.env.NEO4J_TEST_WITH_DOCKER !== undefined;
+const testWithLocalNeo4j = process.env.NEO4J_TEST_WITH_LOCAL !== undefined;
+const shouldTest = testWithDocker || testWithLocalNeo4j;
+
+describe('neo4j instrumentation', { skip: !shouldTest }, () => {
+  let driver: Driver;
+
+  const getSingleSpan = () => {
+    const spans = getTestSpans();
+    assert.equal(spans.length, 1);
+    return spans[0];
+  };
+
+  before(async () => {
+    if (!shouldTest) {
+      suite.skip();
+      return;
+    }
+
+    if (testWithDocker) {
+      startContainer(
+        'docker run --rm -d --name splunk-otel-neo4j -p 11011:7687 -e NEO4J_AUTH=neo4j/test_pw neo4j:4.4.34'
+      );
+    }
+
+    setInstrumentation(instrumentation);
+    driver = neo4j.driver(
+      'bolt://localhost:11011',
+      neo4j.auth.basic('neo4j', 'test_pw'),
+      {
+        disableLosslessIntegers: true,
+      }
+    );
+
+    let keepChecking = true;
+    const timeoutId = setTimeout(() => {
+      keepChecking = false;
+    }, 8000);
+    while (keepChecking) {
+      try {
+        await driver.verifyConnectivity();
+        clearTimeout(timeoutId);
+        return;
+      } catch (err) {
+        await new Promise((res) => setTimeout(res, 1000));
+      }
+    }
+    throw new Error('Could not connect to neo4j in allowed time frame');
+  });
+
+  after(async () => {
+    await driver.close();
+
+    if (testWithDocker) {
+      stopContainer('splunk-otel-neo4j');
+    }
+  });
+
+  beforeEach(async () => {
+    await driver.session().run('MATCH (n) DETACH DELETE n');
+    exporter.reset();
+  });
+
+  afterEach(async () => {
+    instrumentation.setConfig({});
+  });
+
+  describe('session', () => {
+    it('instruments "run" with promise', async () => {
+      const res = await driver.session().run('CREATE (n:MyLabel) RETURN n');
+
+      assert.equal(res.records.length, 1);
+      assert.deepStrictEqual((res.records[0].toObject() as any).n.labels, [
+        'MyLabel',
+      ]);
+
+      const span = getSingleSpan();
+      assertSpan(span);
+      assert.strictEqual(span.name, 'CREATE neo4j');
+      assert.strictEqual(span.attributes[SEMATTRS_DB_OPERATION], 'CREATE');
+      assert.strictEqual(
+        span.attributes[SEMATTRS_DB_STATEMENT],
+        'CREATE (n:MyLabel) RETURN n'
+      );
+    });
+
+    it('instruments "run" with subscribe', (_ctx, done) => {
+      driver
+        .session()
+        .run('CREATE (n:MyLabel) RETURN n')
+        .subscribe({
+          onCompleted: () => {
+            const span = getSingleSpan();
+            assertSpan(span);
+            assert.strictEqual(
+              span.attributes[SEMATTRS_DB_OPERATION],
+              'CREATE'
+            );
+            assert.strictEqual(
+              span.attributes[SEMATTRS_DB_STATEMENT],
+              'CREATE (n:MyLabel) RETURN n'
+            );
+            done();
+          },
+        });
+    });
+
+    it('handles "run" exceptions with promise', async () => {
+      try {
+        await driver.session().run('NOT_EXISTS_OPERATION');
+      } catch (err) {
+        const span = getSingleSpan();
+        assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+        assert.strictEqual(span.status.message, err.message);
+        return;
+      }
+      throw Error('should not be here');
+    });
+
+    it('handles "run" exceptions with subscribe', (_ctx, done) => {
+      driver
+        .session()
+        .run('NOT_EXISTS_OPERATION')
+        .subscribe({
+          onError: (err) => {
+            const span = getSingleSpan();
+            assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+            assert.strictEqual(span.status.message, err.message);
+            done();
+          },
+        });
+    });
+
+    it('closes span when on "onKeys" event', (_ctx, done) => {
+      driver
+        .session()
+        .run('MATCH (n) RETURN n')
+        .subscribe({
+          onKeys: (keys) => {
+            const span = getSingleSpan();
+            assertSpan(span);
+            assert.deepStrictEqual(keys, ['n']);
+            done();
+          },
+        });
+    });
+
+    it('when passing "onKeys" and onCompleted, span is closed in onCompleted, and response hook is called', (_ctx, done) => {
+      instrumentation.setConfig({
+        responseHook: (span) => span.setAttribute('test', 'cool'),
+      });
+
+      driver
+        .session()
+        .run('MATCH (n) RETURN n')
+        .subscribe({
+          onKeys: () => {
+            const spans = getTestSpans();
+            assert.strictEqual(spans.length, 0);
+          },
+          onCompleted: () => {
+            const span = getSingleSpan();
+            assertSpan(span);
+            assert.strictEqual(span.attributes['test'], 'cool');
+            done();
+          },
+        });
+    });
+
+    it('handles multiple promises', async () => {
+      await Promise.all([
+        driver.session().run('MATCH (n) RETURN n'),
+        driver.session().run('MATCH (k) RETURN k'),
+        driver.session().run('MATCH (d) RETURN d'),
+      ]);
+      const spans = getTestSpans();
+      assert.strictEqual(spans.length, 3);
+      for (const span of spans) {
+        assertSpan(span);
+        assert.strictEqual(span.attributes[SEMATTRS_DB_OPERATION], 'MATCH');
+      }
+    });
+
+    it('captures operation with trailing white spaces', async () => {
+      await driver.session().run('  MATCH (k) RETURN k ');
+      const span = getSingleSpan();
+      assert.strictEqual(span.attributes[SEMATTRS_DB_OPERATION], 'MATCH');
+    });
+
+    it('does not capture any span when ignoreOrphanedSpans is set to true', async () => {
+      instrumentation.setConfig({ ignoreOrphanedSpans: true });
+      await context.with(ROOT_CONTEXT, async () => {
+        await driver.session().run('CREATE (n:MyLabel) RETURN n');
+      });
+
+      const spans = getTestSpans();
+      assert.strictEqual(spans.length, 0);
+    });
+
+    it('does capture span when ignoreOrphanedSpans is set to true and has parent span', async () => {
+      instrumentation.setConfig({ ignoreOrphanedSpans: true });
+      const parent = trace
+        .getTracerProvider()
+        .getTracer('test-tracer')
+        .startSpan('main');
+      await context.with(trace.setSpan(context.active(), parent), () => {
+        return driver.session().run('CREATE (n:MyLabel) RETURN n');
+      });
+
+      const spans = getTestSpans();
+      assert.strictEqual(spans.length, 1);
+    });
+
+    it('responseHook works with promise', async () => {
+      instrumentation.setConfig({
+        responseHook: (span, response) => {
+          span.setAttribute('db.response', normalizeResponse(response));
+        },
+      });
+
+      const res = await driver
+        .session()
+        .run(
+          'CREATE (n:Rick), (b:Meeseeks { purpose: "help"}), (c:Morty) RETURN *'
+        );
+      assert.strictEqual(res.records.length, 1);
+
+      const span = getSingleSpan();
+      assertSpan(span);
+      assert.deepStrictEqual(
+        JSON.parse(span.attributes['db.response'] as string),
+        [
+          {
+            b: { labels: ['Meeseeks'], properties: { purpose: 'help' } },
+            c: { labels: ['Morty'], properties: {} },
+            n: { labels: ['Rick'], properties: {} },
+          },
+        ]
+      );
+    });
+
+    it('responseHook works with subscribe', (_ctx, done) => {
+      instrumentation.setConfig({
+        responseHook: (span, response) => {
+          span.setAttribute('db.response', normalizeResponse(response));
+        },
+      });
+
+      driver
+        .session()
+        .run(
+          'CREATE (n:Rick), (b:Meeseeks { purpose: "help"}), (c:Morty) RETURN *'
+        )
+        .subscribe({
+          onCompleted: () => {
+            const span = getSingleSpan();
+            assertSpan(span);
+            assert.deepStrictEqual(
+              JSON.parse(span.attributes['db.response'] as string),
+              [
+                {
+                  b: { labels: ['Meeseeks'], properties: { purpose: 'help' } },
+                  c: { labels: ['Morty'], properties: {} },
+                  n: { labels: ['Rick'], properties: {} },
+                },
+              ]
+            );
+            done();
+          },
+        });
+    });
+
+    it('does not fail when responseHook throws', async () => {
+      instrumentation.setConfig({
+        responseHook: () => {
+          throw new Error('I throw..');
+        },
+      });
+      await driver.session().run('CREATE (n:MyLabel) RETURN n');
+      const span = getSingleSpan();
+      assertSpan(span);
+    });
+  });
+
+  describe('transaction', async () => {
+    it('instruments session readTransaction', async () => {
+      await driver.session().readTransaction((txc) => {
+        return txc.run('MATCH (person:Person) RETURN person.name AS name');
+      });
+      const span = getSingleSpan();
+      assertSpan(span);
+      assert.strictEqual(span.attributes[SEMATTRS_DB_OPERATION], 'MATCH');
+      assert.strictEqual(
+        span.attributes[SEMATTRS_DB_STATEMENT],
+        'MATCH (person:Person) RETURN person.name AS name'
+      );
+    });
+
+    it('instruments session writeTransaction', async () => {
+      await driver.session().writeTransaction((txc) => {
+        return txc.run('MATCH (person:Person) RETURN person.name AS name');
+      });
+      const span = getSingleSpan();
+      assertSpan(span);
+      assert.strictEqual(span.attributes[SEMATTRS_DB_OPERATION], 'MATCH');
+      assert.strictEqual(
+        span.attributes[SEMATTRS_DB_STATEMENT],
+        'MATCH (person:Person) RETURN person.name AS name'
+      );
+    });
+
+    it('instruments explicit transactions', async () => {
+      const txc = driver.session().beginTransaction();
+      await txc.run('MERGE (bob:Person {name: "Bob"}) RETURN bob.name AS name');
+      await txc.run(
+        'MERGE (adam:Person {name: "Adam"}) RETURN adam.name AS name'
+      );
+      await txc.commit();
+
+      const spans = getTestSpans();
+      assert.strictEqual(spans.length, 2);
+    });
+  });
+
+  describe('rxSession', () => {
+    it('instruments "run"', (_ctx, done) => {
+      driver
+        .rxSession()
+        .run('MERGE (n:MyLabel) RETURN n')
+        .records()
+        .subscribe({
+          complete: () => {
+            const span = getSingleSpan();
+            assertSpan(span);
+            done();
+          },
+        });
+    });
+
+    it('works when piping response', (_ctx, done) => {
+      const rxSession = driver.rxSession();
+      rxSession
+        .run(
+          'MERGE (james:Person {name: $nameParam}) RETURN james.name AS name',
+          {
+            nameParam: 'Bob',
+          }
+        )
+        .records()
+        .pipe(map((record) => record.get('name')))
+        .subscribe({
+          next: () => {},
+          complete: () => {
+            const span = getSingleSpan();
+            assertSpan(span);
+            assert.strictEqual(
+              span.attributes[SEMATTRS_DB_STATEMENT],
+              'MERGE (james:Person {name: $nameParam}) RETURN james.name AS name'
+            );
+            done();
+          },
+          error: () => {},
+        });
+    });
+
+    it('works with response hook', (_ctx, done) => {
+      instrumentation.setConfig({
+        responseHook: (span, response) => {
+          span.setAttribute('db.response', normalizeResponse(response));
+        },
+      });
+
+      driver
+        .rxSession()
+        .run('MERGE (n:MyLabel) RETURN n')
+        .records()
+        .subscribe({
+          complete: () => {
+            const span = getSingleSpan();
+            assertSpan(span);
+            assert.strictEqual(
+              span.attributes['db.response'],
+              `[{"n":{"labels":["MyLabel"],"properties":{}}}]`
+            );
+            done();
+          },
+        });
+    });
+  });
+
+  describe('reactive transaction', () => {
+    it('instruments rx session readTransaction', (_ctx, done) => {
+      driver
+        .rxSession()
+        .readTransaction((txc) =>
+          txc
+            .run('MATCH (person:Person) RETURN person.name AS name')
+            .records()
+            .pipe(map((record) => record.get('name')))
+        )
+        .subscribe({
+          next: () => {},
+          complete: () => {
+            const span = getSingleSpan();
+            assert.strictEqual(
+              span.attributes[SEMATTRS_DB_STATEMENT],
+              'MATCH (person:Person) RETURN person.name AS name'
+            );
+            done();
+          },
+          error: () => {},
+        });
+    });
+
+    it('instruments rx session writeTransaction', (_ctx, done) => {
+      driver
+        .rxSession()
+        .writeTransaction((txc) =>
+          txc
+            .run('MATCH (person:Person) RETURN person.name AS name')
+            .records()
+            .pipe(map((record) => record.get('name')))
+        )
+        .subscribe({
+          next: () => {},
+          complete: () => {
+            const span = getSingleSpan();
+            assertSpan(span);
+            assert.strictEqual(
+              span.attributes[SEMATTRS_DB_STATEMENT],
+              'MATCH (person:Person) RETURN person.name AS name'
+            );
+            done();
+          },
+          error: () => {},
+        });
+    });
+
+    it('instruments rx explicit transactions', (_ctx, done) => {
+      driver
+        .rxSession()
+        .beginTransaction()
+        .pipe(
+          mergeMap((txc) =>
+            concat(
+              txc
+                .run(
+                  'MERGE (bob:Person {name: $nameParam}) RETURN bob.name AS name',
+                  {
+                    nameParam: 'Bob',
+                  }
+                )
+                .records()
+                .pipe(map((r: any) => r.get('name'))),
+              txc
+                .run(
+                  'MERGE (adam:Person {name: $nameParam}) RETURN adam.name AS name',
+                  {
+                    nameParam: 'Adam',
+                  }
+                )
+                .records()
+                .pipe(map((r: any) => r.get('name'))),
+              txc.commit()
+            )
+          )
+        )
+        .subscribe({
+          next: () => {},
+          complete: () => {
+            const spans = getTestSpans();
+            assert.strictEqual(spans.length, 2);
+            done();
+          },
+          error: () => {},
+        });
+    });
+  });
+
+  describe('routing mode', () => {
+    // When the connection string starts with "neo4j" routing mode is used
+    let routingDriver: Driver;
+    const version = require('neo4j-driver/package.json').version;
+    const shouldCheck = !['4.0.0', '4.0.1', '4.0.2'].includes(version);
+
+    before(() => {
+      if (shouldCheck) {
+        routingDriver = neo4j.driver(
+          'neo4j://localhost:11011',
+          neo4j.auth.basic('neo4j', 'test_pw')
+        );
+      }
+    });
+
+    after(async () => {
+      if (shouldCheck) {
+        await routingDriver.close();
+      }
+    });
+
+    it('instruments as expected in routing mode', async () => {
+      if (!shouldCheck) {
+        // Versions 4.0.0, 4.0.1 and 4.0.2 of neo4j-driver don't allow connection to local neo4j in routing mode.
+        console.log(`Skipping unsupported test for version ${version}`);
+        return;
+      }
+
+      await routingDriver.session().run('CREATE (n:MyLabel) RETURN n');
+
+      const span = getSingleSpan();
+      assertSpan(span);
+    });
+  });
+});

--- a/test/instrumentation/external/neo4j/neo4j.test.ts
+++ b/test/instrumentation/external/neo4j/neo4j.test.ts
@@ -31,9 +31,9 @@ import {
 } from '@opentelemetry/api';
 import { Neo4jInstrumentation } from '../../../../src/instrumentations/external/neo4j';
 import {
-  SEMATTRS_DB_OPERATION,
-  SEMATTRS_DB_STATEMENT,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_DB_OPERATION,
+  ATTR_DB_STATEMENT,
+} from '../../../../src/instrumentations/external/neo4j/semconv';
 import { map, mergeMap } from 'rxjs/operators';
 // eslint-disable-next-line n/no-extraneous-import
 import { concat } from 'rxjs';
@@ -125,9 +125,9 @@ describe('neo4j instrumentation', { skip: !shouldTest }, () => {
       const span = getSingleSpan();
       assertSpan(span);
       assert.strictEqual(span.name, 'CREATE neo4j');
-      assert.strictEqual(span.attributes[SEMATTRS_DB_OPERATION], 'CREATE');
+      assert.strictEqual(span.attributes[ATTR_DB_OPERATION], 'CREATE');
       assert.strictEqual(
-        span.attributes[SEMATTRS_DB_STATEMENT],
+        span.attributes[ATTR_DB_STATEMENT],
         'CREATE (n:MyLabel) RETURN n'
       );
     });
@@ -140,12 +140,9 @@ describe('neo4j instrumentation', { skip: !shouldTest }, () => {
           onCompleted: () => {
             const span = getSingleSpan();
             assertSpan(span);
+            assert.strictEqual(span.attributes[ATTR_DB_OPERATION], 'CREATE');
             assert.strictEqual(
-              span.attributes[SEMATTRS_DB_OPERATION],
-              'CREATE'
-            );
-            assert.strictEqual(
-              span.attributes[SEMATTRS_DB_STATEMENT],
+              span.attributes[ATTR_DB_STATEMENT],
               'CREATE (n:MyLabel) RETURN n'
             );
             done();
@@ -225,14 +222,14 @@ describe('neo4j instrumentation', { skip: !shouldTest }, () => {
       assert.strictEqual(spans.length, 3);
       for (const span of spans) {
         assertSpan(span);
-        assert.strictEqual(span.attributes[SEMATTRS_DB_OPERATION], 'MATCH');
+        assert.strictEqual(span.attributes[ATTR_DB_OPERATION], 'MATCH');
       }
     });
 
     it('captures operation with trailing white spaces', async () => {
       await driver.session().run('  MATCH (k) RETURN k ');
       const span = getSingleSpan();
-      assert.strictEqual(span.attributes[SEMATTRS_DB_OPERATION], 'MATCH');
+      assert.strictEqual(span.attributes[ATTR_DB_OPERATION], 'MATCH');
     });
 
     it('does not capture any span when ignoreOrphanedSpans is set to true', async () => {
@@ -337,9 +334,9 @@ describe('neo4j instrumentation', { skip: !shouldTest }, () => {
       });
       const span = getSingleSpan();
       assertSpan(span);
-      assert.strictEqual(span.attributes[SEMATTRS_DB_OPERATION], 'MATCH');
+      assert.strictEqual(span.attributes[ATTR_DB_OPERATION], 'MATCH');
       assert.strictEqual(
-        span.attributes[SEMATTRS_DB_STATEMENT],
+        span.attributes[ATTR_DB_STATEMENT],
         'MATCH (person:Person) RETURN person.name AS name'
       );
     });
@@ -350,9 +347,9 @@ describe('neo4j instrumentation', { skip: !shouldTest }, () => {
       });
       const span = getSingleSpan();
       assertSpan(span);
-      assert.strictEqual(span.attributes[SEMATTRS_DB_OPERATION], 'MATCH');
+      assert.strictEqual(span.attributes[ATTR_DB_OPERATION], 'MATCH');
       assert.strictEqual(
-        span.attributes[SEMATTRS_DB_STATEMENT],
+        span.attributes[ATTR_DB_STATEMENT],
         'MATCH (person:Person) RETURN person.name AS name'
       );
     });
@@ -402,7 +399,7 @@ describe('neo4j instrumentation', { skip: !shouldTest }, () => {
             const span = getSingleSpan();
             assertSpan(span);
             assert.strictEqual(
-              span.attributes[SEMATTRS_DB_STATEMENT],
+              span.attributes[ATTR_DB_STATEMENT],
               'MERGE (james:Person {name: $nameParam}) RETURN james.name AS name'
             );
             done();
@@ -451,7 +448,7 @@ describe('neo4j instrumentation', { skip: !shouldTest }, () => {
           complete: () => {
             const span = getSingleSpan();
             assert.strictEqual(
-              span.attributes[SEMATTRS_DB_STATEMENT],
+              span.attributes[ATTR_DB_STATEMENT],
               'MATCH (person:Person) RETURN person.name AS name'
             );
             done();
@@ -475,7 +472,7 @@ describe('neo4j instrumentation', { skip: !shouldTest }, () => {
             const span = getSingleSpan();
             assertSpan(span);
             assert.strictEqual(
-              span.attributes[SEMATTRS_DB_STATEMENT],
+              span.attributes[ATTR_DB_STATEMENT],
               'MATCH (person:Person) RETURN person.name AS name'
             );
             done();

--- a/test/instrumentation/external/neo4j/neo4j.test.ts
+++ b/test/instrumentation/external/neo4j/neo4j.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright Splunk Inc.
+ * Copyright Splunk Inc., Aspecto
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/instrumentation/external/neo4j/utils.ts
+++ b/test/instrumentation/external/neo4j/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright Splunk Inc.
+ * Copyright Splunk Inc., Aspecto
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/instrumentation/external/neo4j/utils.ts
+++ b/test/instrumentation/external/neo4j/utils.ts
@@ -17,13 +17,13 @@ import { strict as assert } from 'assert';
 import { QueryResult } from 'neo4j-driver';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import {
-  SEMATTRS_DB_NAME,
-  SEMATTRS_DB_SYSTEM,
-  SEMATTRS_DB_USER,
-  SEMATTRS_NET_PEER_NAME,
-  SEMATTRS_NET_PEER_PORT,
-  SEMATTRS_NET_TRANSPORT,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_DB_NAME,
+  ATTR_DB_SYSTEM,
+  ATTR_DB_USER,
+  ATTR_NET_PEER_NAME,
+  ATTR_NET_PEER_PORT,
+  ATTR_NET_TRANSPORT,
+} from '../../../../src/instrumentations/external/neo4j/semconv';
 import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
 
 export const normalizeResponse = (response: QueryResult) => {
@@ -40,10 +40,10 @@ export const normalizeResponse = (response: QueryResult) => {
 export const assertSpan = (span: ReadableSpan) => {
   assert.strictEqual(span.kind, SpanKind.CLIENT);
   assert.strictEqual(span.status.code, SpanStatusCode.UNSET);
-  assert.strictEqual(span.attributes[SEMATTRS_DB_SYSTEM], 'neo4j');
-  assert.strictEqual(span.attributes[SEMATTRS_DB_NAME], 'neo4j');
-  assert.strictEqual(span.attributes[SEMATTRS_DB_USER], 'neo4j');
-  assert.strictEqual(span.attributes[SEMATTRS_NET_PEER_NAME], 'localhost');
-  assert.strictEqual(span.attributes[SEMATTRS_NET_PEER_PORT], 11011);
-  assert.strictEqual(span.attributes[SEMATTRS_NET_TRANSPORT], 'IP.TCP');
+  assert.strictEqual(span.attributes[ATTR_DB_SYSTEM], 'neo4j');
+  assert.strictEqual(span.attributes[ATTR_DB_NAME], 'neo4j');
+  assert.strictEqual(span.attributes[ATTR_DB_USER], 'neo4j');
+  assert.strictEqual(span.attributes[ATTR_NET_PEER_NAME], 'localhost');
+  assert.strictEqual(span.attributes[ATTR_NET_PEER_PORT], 11011);
+  assert.strictEqual(span.attributes[ATTR_NET_TRANSPORT], 'IP.TCP');
 };

--- a/test/instrumentation/external/neo4j/utils.ts
+++ b/test/instrumentation/external/neo4j/utils.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { strict as assert } from 'assert';
+import { QueryResult } from 'neo4j-driver';
+import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import {
+  SEMATTRS_DB_NAME,
+  SEMATTRS_DB_SYSTEM,
+  SEMATTRS_DB_USER,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
+  SEMATTRS_NET_TRANSPORT,
+} from '@opentelemetry/semantic-conventions';
+import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
+
+export const normalizeResponse = (response: QueryResult) => {
+  return JSON.stringify(
+    response.records.map((r) => {
+      const asObject = r.toObject();
+      r.keys.forEach((key) => delete asObject[key as any].identity);
+
+      return asObject;
+    })
+  );
+};
+
+export const assertSpan = (span: ReadableSpan) => {
+  assert.strictEqual(span.kind, SpanKind.CLIENT);
+  assert.strictEqual(span.status.code, SpanStatusCode.UNSET);
+  assert.strictEqual(span.attributes[SEMATTRS_DB_SYSTEM], 'neo4j');
+  assert.strictEqual(span.attributes[SEMATTRS_DB_NAME], 'neo4j');
+  assert.strictEqual(span.attributes[SEMATTRS_DB_USER], 'neo4j');
+  assert.strictEqual(span.attributes[SEMATTRS_NET_PEER_NAME], 'localhost');
+  assert.strictEqual(span.attributes[SEMATTRS_NET_PEER_PORT], 11011);
+  assert.strictEqual(span.attributes[SEMATTRS_NET_TRANSPORT], 'IP.TCP');
+};

--- a/test/instrumentation/external/neo4j/utils.ts
+++ b/test/instrumentation/external/neo4j/utils.ts
@@ -29,10 +29,18 @@ import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
 export const normalizeResponse = (response: QueryResult) => {
   return JSON.stringify(
     response.records.map((r) => {
-      const asObject = r.toObject();
-      r.keys.forEach((key) => delete asObject[key as any].identity);
+      const record = r.toObject();
+      const normalized = {};
 
-      return asObject;
+      for (const k in record) {
+        const node = record[k];
+        normalized[k] = {
+          labels: node['labels'],
+          properties: node['properties'],
+        };
+      }
+
+      return normalized;
     })
   );
 };

--- a/test/runner.js
+++ b/test/runner.js
@@ -53,3 +53,6 @@ const testProcess = spawn('node', args);
 
 testProcess.stdout.pipe(process.stdout);
 testProcess.stderr.pipe(process.stderr);
+testProcess.on('exit', (code) => {
+  process.exit(code);
+});


### PR DESCRIPTION
Ported over Aspecto's [neo4j instrumentation](https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-neo4j).

Changes:
* Support version 5.x
* Added additional typing
* Moved tests to `node:test`
* Converted deprecated attributes to local `ATTR_` keys.
* Fixed the case where spans were being ended twice

