### PR TITLE
chore: release v3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @splunk/otel
 
+## 3.1.2
+
+- Add prebuilds for Apple silicon. [#1016](https://github.com/signalfx/splunk-otel-js/pull/1016)
+- Fix compilation on macOS with Xcode 16.3. [#1016](https://github.com/signalfx/splunk-otel-js/pull/1016)
+
 ## 3.1.1
 
 - Fix loading of neo4j-driver instrumentation. [#1013](https://github.com/signalfx/splunk-otel-js/pull/1013)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '3.1.1';
+export const VERSION = '3.1.2';


### PR DESCRIPTION
- Add prebuilds for Apple silicon. [#1016](https://github.com/signalfx/splunk-otel-js/pull/1016)
- Fix compilation on macOS with Xcode 16.3. [#1016](https://github.com/signalfx/splunk-otel-js/pull/1016)