### PR TITLE
chore: release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - @splunk/otel
 
+## 3.2.0
+
+- Upgrade to OpenTelemetry `1.30.1` / `0.57.2`. [#1024](https://github.com/signalfx/splunk-otel-js/pull/1024)
+- Add prebuilt binaries for Node.js 24. [#1024](https://github.com/signalfx/splunk-otel-js/pull/1024)
+- Add support for snapshot profiling (callgraphs). [#1023](https://github.com/signalfx/splunk-otel-js/pull/1023)
+
 ## 3.1.2
 
 - Add prebuilds for Apple silicon. [#1016](https://github.com/signalfx/splunk-otel-js/pull/1016)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '3.1.2';
+export const VERSION = '3.2.0';


### PR DESCRIPTION
- Upgrade to OpenTelemetry `1.30.1` / `0.57.2`. [#1024](https://github.com/signalfx/splunk-otel-js/pull/1024)
- Add prebuilt binaries for Node.js 24. [#1024](https://github.com/signalfx/splunk-otel-js/pull/1024)
- Add support for snapshot profiling (callgraphs). [#1023](https://github.com/signalfx/splunk-otel-js/pull/1023)