### PR TITLE
fix: pass the searched artifact name to octokit

### DIFF
--- a/scripts/prepare-release-artifact.js
+++ b/scripts/prepare-release-artifact.js
@@ -65,15 +65,16 @@ async function getBuildArtifact() {
 
   console.log('found finished workflow run', run);
 
+  const tgzName = `splunk-otel-${version}.tgz`
   const { data: artifacts } = await octokit.rest.actions.listWorkflowRunArtifacts({
     owner,
     repo,
     run_id: run.id,
+    name: tgzName,
   });
 
   console.log('found artifacts for workflow', artifacts);
 
-  const tgzName = `splunk-otel-${version}.tgz`
   const packageArtifact = artifacts.artifacts.find(artifact => artifact.name === tgzName);
 
   if (packageArtifact === undefined) {


### PR DESCRIPTION
The max number of artifacts from `listWorkflowRunArtifacts` now exceeds the limit of 100, so some of them will be missing in the results. octokit provides a way to filter them at the source