### PR TITLE
chore: release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
         metrics: { views: [{ name: 'clicks', instrumentName: 'my-counter', }], },
       })
       ```
-  * [`@opentelemetry/instrumentation-fastify`](https://www.npmjs.com/package/@opentelemetry/instrumentation-fastify) has been deprecated and is replaced with [`@fastify/otel`](https://www.npmjs.com/package/@fastify/otel).
+- [`@opentelemetry/instrumentation-fastify`](https://www.npmjs.com/package/@opentelemetry/instrumentation-fastify) has been deprecated and is replaced with [`@fastify/otel`](https://www.npmjs.com/package/@fastify/otel).
 - Add an experimental HTTP instrumentation based on diagnostics channel. [#1021](https://github.com/signalfx/splunk-otel-js/pull/1021)
 - Add `oracledb` and `openai` instrumentations. [#1041](https://github.com/signalfx/splunk-otel-js/pull/1041)
 - New `nocode` instrumentation that allows instrumenting of custom code. Refer to the [overview](https://github.com/signalfx/splunk-otel-js/blob/main/src/instrumentations/external/nocode/nocode.md) for usage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 - Add an experimental HTTP instrumentation based on diagnostics channel. [#1021](https://github.com/signalfx/splunk-otel-js/pull/1021)
 - Add `oracledb` and `openai` instrumentations. [#1041](https://github.com/signalfx/splunk-otel-js/pull/1041)
 - New `nocode` instrumentation that allows instrumenting of custom code. Refer to the [overview](https://github.com/signalfx/splunk-otel-js/blob/main/src/instrumentations/external/nocode/nocode.md) for usage.
-- `typeorm` instrumentation has migrated to [upstream](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-typeorm) and is now using updated semantic conventions, e.g. `db.namespace`, `db.operatio.name`, `db.collection.name`, `db.query.text`, `db.system.name`.
+- `typeorm` instrumentation has migrated to [upstream](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-typeorm) and is now using updated semantic conventions, e.g. `db.namespace`, `db.operation.name`, `db.collection.name`, `db.query.text`, `db.system.name`.
 - `@opentelemetry/instrumentation-redis-4` has been removed as it has been merged to `@opentelemetry/instrumentation-redis` in the upstream.
 
 ## 3.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "4.0.0-alpha1",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "4.0.0-alpha1",
+      "version": "4.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "4.0.0-alpha1",
+  "version": "4.0.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '4.0.0-alpha1';
+export const VERSION = '4.0.0';


### PR DESCRIPTION
- Upgrade to OpenTelemetry SDK 2.0. [#1020](https://github.com/signalfx/splunk-otel-js/pull/1020).
  * Minimum Node.js version has been bumped to `^18.19.0 || >=20.6.0`.
  * Refer to https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0 and the [upgrade guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md) for the complete list of breaking changes in OpenTelemetry JS.
  * Notable changes relevant to `@splunk/otel`:
    * Resource can no longer be created with `new Resource({})`, instead use `resourceFromAttributes({})` when passing in a resource:
      ```ts
      import { start } from '@splunk/otel';
      import { resourceFromAttributes } from '@opentelemetry/resources';

      start({
        resource: (detectedResource) => {
          return detectedResource.merge(resourceFromAttributes({
            'my.attribute': 'foo',
          }));
        },
      })
      ```
    * `Span` no longer has a `parentSpanId` field, use `parentSpanContext.spanId`:
      ```ts
      import { start } from '@splunk/otel';
      import { Context } from '@opentelemetry/api';
      import { ReadableSpan, Span } from '@opentelemetry/sdk-trace-base';
      import { SpanProcessor } from '@opentelemetry/sdk-trace-base';

      class MySpanProcessor implements SpanProcessor {
        onStart(span: Span, _parentContext: Context): void {
          console.log(span.parentSpanContext?.spanId);
        }

        onEnd(span: ReadableSpan): void {
          console.log(span.parentSpanContext?.spanId);
        }

        forceFlush(): Promise<void> {
          return Promise.resolve();
        }

        shutdown(): Promise<void> {
          return Promise.resolve();
        }
      }

      start({
        tracing: {
          spanProcessorFactory: (_opts) => [new MySpanProcessor()],
        },
      });
      ```
    * Passing in custom views to metrics is now done via `ViewOptions` interface instead of `new View({ ... })`:
      ```ts
      import { start } from '@splunk/otel';

      start({
        metrics: { views: [{ name: 'clicks', instrumentName: 'my-counter', }], },
      })
      ```
- [`@opentelemetry/instrumentation-fastify`](https://www.npmjs.com/package/@opentelemetry/instrumentation-fastify) has been deprecated and is replaced with [`@fastify/otel`](https://www.npmjs.com/package/@fastify/otel).
- Add an experimental HTTP instrumentation based on diagnostics channel. [#1021](https://github.com/signalfx/splunk-otel-js/pull/1021)
- Add `oracledb` and `openai` instrumentations. [#1041](https://github.com/signalfx/splunk-otel-js/pull/1041)
- New `nocode` instrumentation that allows instrumenting of custom code. Refer to the [overview](https://github.com/signalfx/splunk-otel-js/blob/main/src/instrumentations/external/nocode/nocode.md) for usage.
- `typeorm` instrumentation has migrated to [upstream](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-typeorm) and is now using updated semantic conventions, e.g. `db.namespace`, `db.operatio.name`, `db.collection.name`, `db.query.text`, `db.system.name`.
- `@opentelemetry/instrumentation-redis-4` has been removed as it has been merged to `@opentelemetry/instrumentation-redis` in the upstream.