### PR TITLE
chore: update to otel 2.1.0 / 0.205.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@fastify/otel": "0.9.4",
+        "@fastify/otel": "0.10.0",
         "@grpc/grpc-js": "^1.13.4",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.205.0",
@@ -712,9 +712,9 @@
       }
     },
     "node_modules/@fastify/otel": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.9.4.tgz",
-      "integrity": "sha512-NboTg+WAJPQ/prwmXA9ey2araV2Dj5+5NoCP5dZ5sI49wGKuZZ3k0kGLiFD1CIPEh2bI2G2HXF7ozTbDauh9Yg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.10.0.tgz",
+      "integrity": "sha512-+I1f1dWgQqfktjvW0Krw05oYoFjFiw4PIe/rWsoTeADtD6fE7OTCgf9l1axanWDxL5yZxksBP7kBUS5NlnmS0w==",
       "funding": [
         {
           "type": "github",
@@ -728,41 +728,12 @@
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.203.0",
+        "@opentelemetry/instrumentation": "^0.205.0",
         "@opentelemetry/semantic-conventions": "^1.28.0",
         "minimatch": "^10.0.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0"
-      }
-    },
-    "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
-      "version": "0.203.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz",
-      "integrity": "sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.203.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.203.0.tgz",
-      "integrity": "sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.203.0",
-        "import-in-the-middle": "^1.8.1",
-        "require-in-the-middle": "^7.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@fastify/otel/node_modules/minimatch": {
@@ -2556,6 +2527,32 @@
       "resolved": "packages/otel-esbuild-plugin",
       "link": true
     },
+    "node_modules/@splunk/otel/node_modules/@fastify/otel": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.9.4.tgz",
+      "integrity": "sha512-NboTg+WAJPQ/prwmXA9ey2araV2Dj5+5NoCP5dZ5sI49wGKuZZ3k0kGLiFD1CIPEh2bI2G2HXF7ozTbDauh9Yg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.203.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "minimatch": "^10.0.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
     "node_modules/@splunk/otel/node_modules/@opentelemetry/api-logs": {
       "version": "0.203.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz",
@@ -3640,6 +3637,22 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@splunk/otel/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -9213,34 +9226,16 @@
       "dev": true
     },
     "@fastify/otel": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.9.4.tgz",
-      "integrity": "sha512-NboTg+WAJPQ/prwmXA9ey2araV2Dj5+5NoCP5dZ5sI49wGKuZZ3k0kGLiFD1CIPEh2bI2G2HXF7ozTbDauh9Yg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.10.0.tgz",
+      "integrity": "sha512-+I1f1dWgQqfktjvW0Krw05oYoFjFiw4PIe/rWsoTeADtD6fE7OTCgf9l1axanWDxL5yZxksBP7kBUS5NlnmS0w==",
       "requires": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.203.0",
+        "@opentelemetry/instrumentation": "^0.205.0",
         "@opentelemetry/semantic-conventions": "^1.28.0",
         "minimatch": "^10.0.3"
       },
       "dependencies": {
-        "@opentelemetry/api-logs": {
-          "version": "0.203.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz",
-          "integrity": "sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==",
-          "requires": {
-            "@opentelemetry/api": "^1.3.0"
-          }
-        },
-        "@opentelemetry/instrumentation": {
-          "version": "0.203.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.203.0.tgz",
-          "integrity": "sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==",
-          "requires": {
-            "@opentelemetry/api-logs": "0.203.0",
-            "import-in-the-middle": "^1.8.1",
-            "require-in-the-middle": "^7.1.1"
-          }
-        },
         "minimatch": {
           "version": "10.0.3",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
@@ -10438,6 +10433,18 @@
         "semver": "^7.7.2"
       },
       "dependencies": {
+        "@fastify/otel": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.9.4.tgz",
+          "integrity": "sha512-NboTg+WAJPQ/prwmXA9ey2araV2Dj5+5NoCP5dZ5sI49wGKuZZ3k0kGLiFD1CIPEh2bI2G2HXF7ozTbDauh9Yg==",
+          "peer": true,
+          "requires": {
+            "@opentelemetry/core": "^2.0.0",
+            "@opentelemetry/instrumentation": "^0.203.0",
+            "@opentelemetry/semantic-conventions": "^1.28.0",
+            "minimatch": "^10.0.3"
+          }
+        },
         "@opentelemetry/api-logs": {
           "version": "0.203.0",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz",
@@ -11106,6 +11113,15 @@
             "@types/node": "*",
             "pg-protocol": "*",
             "pg-types": "^2.2.0"
+          }
+        },
+        "minimatch": {
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+          "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+          "peer": true,
+          "requires": {
+            "@isaacs/brace-expansion": "^5.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "winston": "3.10.0"
   },
   "dependencies": {
-    "@fastify/otel": "0.9.4",
+    "@fastify/otel": "0.10.0",
     "@grpc/grpc-js": "^1.13.4",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.205.0",


### PR DESCRIPTION
Waiting for the fastify instrumentation to be released as it is depending on instrumentation `0.203.0` at the moment