### PR TITLE
fix: add back telemetry.sdk.* attributes

### DIFF
--- a/src/detectors/TelemetrySdkDetector.ts
+++ b/src/detectors/TelemetrySdkDetector.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DetectedResource,
+  ResourceDetectionConfig,
+  resourceFromAttributes,
+} from '@opentelemetry/resources';
+
+import { SDK_INFO } from '@opentelemetry/core';
+import {
+  ATTR_TELEMETRY_SDK_LANGUAGE,
+  ATTR_TELEMETRY_SDK_NAME,
+  ATTR_TELEMETRY_SDK_VERSION,
+} from '@opentelemetry/semantic-conventions';
+
+class TelemetrySdkDetector {
+  detect(_config?: ResourceDetectionConfig): DetectedResource {
+    // omitting ATTR_SERVICE_NAME cause we use our own defaultServiceName
+    return resourceFromAttributes({
+      [ATTR_TELEMETRY_SDK_LANGUAGE]: SDK_INFO[ATTR_TELEMETRY_SDK_LANGUAGE],
+      [ATTR_TELEMETRY_SDK_NAME]: SDK_INFO[ATTR_TELEMETRY_SDK_NAME],
+      [ATTR_TELEMETRY_SDK_VERSION]: SDK_INFO[ATTR_TELEMETRY_SDK_VERSION],
+    });
+  }
+}
+
+export const telemetrySdkDetector = new TelemetrySdkDetector();

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -24,6 +24,7 @@ import {
 } from '@opentelemetry/resources';
 import { containerDetector } from '@opentelemetry/resource-detector-container';
 import { distroDetector } from './detectors/DistroDetector';
+import { telemetrySdkDetector } from './detectors/TelemetrySdkDetector';
 
 const detectors = [
   distroDetector,
@@ -32,6 +33,7 @@ const detectors = [
   hostDetector,
   osDetector,
   processDetector,
+  telemetrySdkDetector,
 ];
 
 let detectedResource: DetectedResource | undefined;

--- a/test/resource.test.ts
+++ b/test/resource.test.ts
@@ -17,6 +17,11 @@
 import { strict as assert } from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { cleanEnvironment, detectResource } from './utils';
+import {
+  ATTR_TELEMETRY_SDK_LANGUAGE,
+  ATTR_TELEMETRY_SDK_VERSION,
+  ATTR_TELEMETRY_SDK_NAME,
+} from '@opentelemetry/semantic-conventions';
 
 describe('resource detector', () => {
   beforeEach(() => {
@@ -68,6 +73,23 @@ describe('resource detector', () => {
       const resource = detectResource();
       assert.strictEqual(typeof resource.attributes?.['host.name'], 'string');
       assert.strictEqual(typeof resource.attributes?.['host.arch'], 'string');
+    });
+
+    it('adds telemetry.sdk attributes', () => {
+      const resource = detectResource();
+
+      assert.strictEqual(
+        typeof resource.attributes?.[ATTR_TELEMETRY_SDK_LANGUAGE],
+        'string'
+      );
+      assert.strictEqual(
+        typeof resource.attributes?.[ATTR_TELEMETRY_SDK_NAME],
+        'string'
+      );
+      assert.strictEqual(
+        typeof resource.attributes?.[ATTR_TELEMETRY_SDK_VERSION],
+        'string'
+      );
     });
   });
 });


### PR DESCRIPTION
Upstream removed them in https://github.com/open-telemetry/opentelemetry-js/pull/5219. 