### PR TITLE
Remove macos-13 add macos-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, macos-13, macos-14]
+        os: [windows-2022, macos-14, macos-15]
         node_api_target: ['18.0.0', '20.0.0', '21.2.0', '22.0.0', '23.0.0', '24.0.0']
         include:
-          - os: macos-13
-            python_version: '3.11'
           - os: macos-14
+            python_version: '3.11'
+          - os: macos-15
             python_version: '3.11'
     runs-on: ${{ matrix.os }}
     steps:
@@ -107,8 +107,8 @@ jobs:
           cp -r allprebuilds/prebuilds-linux-arm64-*/* prebuilds
           cp -r allprebuilds/prebuilds-linux-*/* prebuilds
           cp -r allprebuilds/prebuilds-windows-2022-*/* prebuilds
-          cp -r allprebuilds/prebuilds-macos-13-*/* prebuilds
           cp -r allprebuilds/prebuilds-macos-14-*/* prebuilds
+          cp -r allprebuilds/prebuilds-macos-15-*/* prebuilds
       - name: Install npm dependencies
         run: npm ci --ignore-scripts
       - name: Build


### PR DESCRIPTION
The macos-13 runners are being retired in the first week of December, so we'd better get ahead of no longer using them.

This simply replaces the macos-13 images with macos-15, which was not being used and might not work. If this lazy attempt fails miserably, please feel free to close it and open an issue or just supersede it with a more thoughtful PR. :)