### PR TITLE
chore: release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @splunk/otel
 
+## 4.1.0
+
+- Upgrade to OpenTelemetry 2.2.0 / 0.207.0. [#1080](https://github.com/signalfx/splunk-otel-js/pull/1080)
+- Add `SPLUNK_SNAPSHOT_SELECTION_PROBABILITY` and `SPLUNK_SNAPSHOT_SAMPLING_INTERVAL` env vars. [#1077](https://github.com/signalfx/splunk-otel-js/pull/1077/)
+
 ## 4.0.1
 
 - Add back `telemetry.sdk.*` attributes. [#1066](https://github.com/signalfx/splunk-otel-js/pull/1066).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "repository": "git@github.com:signalfx/splunk-otel-js.git",
   "author": "Splunk <splunk-oss@splunk.com>",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '4.0.1';
+export const VERSION = '4.1.0';


### PR DESCRIPTION

- Upgrade to OpenTelemetry 2.2.0 / 0.207.0. [#1080](https://github.com/signalfx/splunk-otel-js/pull/1080)
- Add `SPLUNK_SNAPSHOT_SELECTION_PROBABILITY` and `SPLUNK_SNAPSHOT_SAMPLING_INTERVAL` env vars. [#1077](https://github.com/signalfx/splunk-otel-js/pull/1077/)