### PR TITLE
Publishing from GitHub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Publish
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'CI workflow run ID to download the package artifact from'
+        required: true
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    permissions:
+      contents: write
+    steps:
+      - name: Validate version tag
+        run: |
+          if ! [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: tag '${{ github.ref_name }}' does not match vX.Y.Z format"
+            exit 1
+          fi
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
+        with:
+          node-version: 'lts/*'
+      - name: Download package artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: '*.tgz'
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ github.token }}
+          merge-multiple: true
+          path: dist
+      - name: Generate checksums
+        run: shasum -a 256 dist/* > dist/checksums.txt
+      - name: Generate release notes
+        id: release-notes
+        run: |
+          npm ci
+          node -e "
+            import { getReleaseMessage } from './scripts/release-message.mjs';
+            const body = getReleaseMessage('../');
+            const fs = await import('fs');
+            fs.writeFileSync('release-body.md', body);
+          " --input-type=module
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
+        with:
+          tag_name: ${{ github.ref_name }}
+          body_path: release-body.md
+          files: dist/*
+      - name: Publish (dry run)
+        run: npm publish --dry-run dist/*.tgz


### PR DESCRIPTION
Converted the gitlab release script to github. The existing helper scripts (prepare-release-artifact.mjs) are no longer necessary, but keeping them until the pipeline is up and running.

The first test run will be a dry run.

Releases and tags will be deleted manually.