### PR TITLE
chore: release v4.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @splunk/otel
 
+## 4.5.1
+
+- Fix YAML substitution when reporting effective config via OpAMP. [#1125](https://github.com/signalfx/splunk-otel-js/pull/1125)
+- Update protobufjs used by @grpc/proto-loader to 7.5.5 for a [vulnerability fix](https://github.com/advisories/GHSA-xq3m-2v4x-88gg). [#1126](https://github.com/signalfx/splunk-otel-js/pull/1126)
+
 ## 4.5.0
 
 - Use `sequelize` instrumentation from upstream. [#1113](https://github.com/signalfx/splunk-otel-js/pull/1113)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "keywords": [
     "apm",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '4.5.0';
+export const VERSION = '4.5.1';


### PR DESCRIPTION
- Fix YAML substitution when reporting effective config via OpAMP. [#1125](https://github.com/signalfx/splunk-otel-js/pull/1125)
- Update protobufjs used by @grpc/proto-loader to 7.5.5 for a [vulnerability fix](https://github.com/advisories/GHSA-xq3m-2v4x-88gg). [#1126](https://github.com/signalfx/splunk-otel-js/pull/1126)