### PR TITLE
Replace action with simple gh cli usage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,10 +49,11 @@ jobs:
             fs.writeFileSync('release-body.md', body);
           " --input-type=module
       - name: Create GitHub release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
-        with:
-          tag_name: ${{ github.ref_name }}
-          body_path: release-body.md
-          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --notes-file release-body.md \
+            dist/*
       - name: Publish
         run: npm publish ./dist/splunk-otel-${{ steps.version.outputs.value }}.tgz


### PR DESCRIPTION
We can (and should) use the gh cli to create the release, rather than depending on a 3rd party action for this.