### PR TITLE
chore: release v4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @splunk/otel
 
+## 4.6.0
+
+- Upgrade to OpenTelemetry 2.7.0 / 0.215.0. [#1132](https://github.com/signalfx/splunk-otel-js/pull/1132)
+- Vendor in Fastify instrumentation. [#1130](https://github.com/signalfx/splunk-otel-js/pull/1130)
+
 ## 4.5.1
 
 - Fix YAML substitution when reporting effective config via OpAMP. [#1125](https://github.com/signalfx/splunk-otel-js/pull/1125)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "4.5.1",
+      "version": "4.6.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "keywords": [
     "apm",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '4.5.1';
+export const VERSION = '4.6.0';


### PR DESCRIPTION
- Upgrade to OpenTelemetry 2.7.0 / 0.215.0. [#1132](https://github.com/signalfx/splunk-otel-js/pull/1132)
- Vendor in Fastify instrumentation. [#1130](https://github.com/signalfx/splunk-otel-js/pull/1130)