### PR TITLE
chore: release v4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - @splunk/otel
 
+## 4.7.0
+
+- Add SecureApp. Can be enabled with `SPLUNK_SECUREAPP_AGENT_ENABLED`. [#1141](https://github.com/signalfx/splunk-otel-js/pull/1141)
+- Add support for Node.js 26. [#1140](https://github.com/signalfx/splunk-otel-js/pull/1140)
+- Upgrade to OpenTelemetry 2.7.1 / 0.216.0 and API 1.9.1. [#1139](https://github.com/signalfx/splunk-otel-js/pull/1139)
+
 ## 4.6.0
 
 - Upgrade to OpenTelemetry 2.7.0 / 0.215.0. [#1132](https://github.com/signalfx/splunk-otel-js/pull/1132)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "4.6.0",
+      "version": "4.7.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "keywords": [
     "apm",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '4.6.0';
+export const VERSION = '4.7.0';


### PR DESCRIPTION
- Add SecureApp. Can be enabled with `SPLUNK_SECUREAPP_AGENT_ENABLED`. [#1141](https://github.com/signalfx/splunk-otel-js/pull/1141)
- Add support for Node.js 26. [#1140](https://github.com/signalfx/splunk-otel-js/pull/1140)
- Upgrade to OpenTelemetry 2.7.1 / 0.216.0 and API 1.9.1. [#1139](https://github.com/signalfx/splunk-otel-js/pull/1139)