### PR TITLE
chore: release v4.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @splunk/otel
 
+## 4.7.2
+
+- Upgrade to OpenTelemetry 0.218.0. [#1151](https://github.com/signalfx/splunk-otel-js/issues/1151)
+  - Includes a fix to router instrumentation for `MaxListenersExceededWarning`.
+    [js-contrib #3495](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/3495)
+    Fixes [#1134](https://github.com/signalfx/splunk-otel-js/issues/1134).
+
 ## 4.7.1
 
 - Upgrade to OpenTelemetry 2.7.1 / 0.217.0. [#1144](https://github.com/signalfx/splunk-otel-js/issues/1144)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "4.7.1",
+      "version": "4.7.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "keywords": [
     "apm",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '4.7.1';
+export const VERSION = '4.7.2';


### PR DESCRIPTION
- Upgrade to OpenTelemetry 0.218.0. [#1151](https://github.com/signalfx/splunk-otel-js/issues/1151)
  - Includes a fix to router instrumentation for `MaxListenersExceededWarning`.
    [js-contrib #3495](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/3495)
    Fixes [#1134](https://github.com/signalfx/splunk-otel-js/issues/1134).