### PR TITLE
chore: release v4.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @splunk/otel
 
+## 4.9.0
+
+- Upgrade to OpenTelemetry 2.8.0 / 0.219.0. [#1163](https://github.com/signalfx/splunk-otel-js/pull/1163)
+- Add service ID instance detector to default detectors. [#1165](https://github.com/signalfx/splunk-otel-js/pull/1165)
+
 ## 4.8.0
 
 - Align OpAMP with GDI spec. [#1159](https://github.com/signalfx/splunk-otel-js/pull/1159)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "keywords": [
     "apm",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '4.8.0';
+export const VERSION = '4.9.0';


### PR DESCRIPTION
- Upgrade to OpenTelemetry 2.8.0 / 0.219.0. [#1163](https://github.com/signalfx/splunk-otel-js/pull/1163)
- Add service ID instance detector to default detectors. [#1165](https://github.com/signalfx/splunk-otel-js/pull/1165)