### PR TITLE
Prefer OTEL_CONFIG_FILE for config file path, keep EXPERIMENTAL as fallback

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -158,7 +158,7 @@ The following config options can be set by passing them as tracing arguments to 
 
 **Status**: Experimental
 
-An [OpenTelemetry configuration YAML file](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md) can be provided via `OTEL_EXPERIMENTAL_CONFIG_FILE` environment variable. When set, all of the configuration options will be loaded from the given path.
+An [OpenTelemetry configuration YAML file](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md) can be provided via the `OTEL_CONFIG_FILE` environment variable (the deprecated `OTEL_EXPERIMENTAL_CONFIG_FILE` is still supported as a fallback). When set, all of the configuration options will be loaded from the given path.
 
 Other options provided via environment variables will be ignored. Programmatic options sill take preference over the file based configuration.
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -19,6 +19,7 @@ import {
   getEnvArray,
   getEnvBoolean,
   getEnvNumber,
+  getEnvValueByPrecedence,
   getNonEmptyEnvVar,
   resolveOtlpExporterUrl,
 } from './utils';
@@ -1038,12 +1039,17 @@ function getEffectiveDeclarativeConfig(): string {
 
 // The AgentConfigFile name for the declarative format must match the filename
 // of the config that was actually loaded, including its path. The distro loads
-// the declarative config from OTEL_EXPERIMENTAL_CONFIG_FILE (see start.ts), so
-// the name is taken from there rather than OTEL_CONFIG_FILE — otherwise the
-// loaded file's body would be attributed to a path that was never read. A
-// defaulted name must still be provided per spec.
+// the declarative config from OTEL_CONFIG_FILE, falling back to the deprecated
+// OTEL_EXPERIMENTAL_CONFIG_FILE (see start.ts), so the name is taken with the
+// same precedence — otherwise the loaded file's body would be attributed to a
+// path that was never read. A defaulted name must still be provided per spec.
 function effectiveDeclarativeConfigName(): string {
-  return getNonEmptyEnvVar('OTEL_EXPERIMENTAL_CONFIG_FILE') ?? 'config.yaml';
+  return (
+    getEnvValueByPrecedence([
+      'OTEL_CONFIG_FILE',
+      'OTEL_EXPERIMENTAL_CONFIG_FILE',
+    ]) ?? 'config.yaml'
+  );
 }
 
 export function getLoadedConfigurationString(): {

--- a/src/start.ts
+++ b/src/start.ts
@@ -53,7 +53,7 @@ import {
   isSnapshotProfilingEnabled,
   startSnapshotProfiling,
 } from './tracing/snapshots/Snapshots';
-import { getNonEmptyEnvVar } from './utils';
+import { getEnvValueByPrecedence } from './utils';
 import {
   getNonEmptyConfigVar,
   getConfigBoolean,
@@ -114,7 +114,10 @@ export const start = (options: Partial<Options> = {}) => {
     throw new Error('Splunk APM already started');
   }
 
-  const configFilePath = getNonEmptyEnvVar('OTEL_EXPERIMENTAL_CONFIG_FILE');
+  const configFilePath = getEnvValueByPrecedence([
+    'OTEL_CONFIG_FILE',
+    'OTEL_EXPERIMENTAL_CONFIG_FILE',
+  ]);
   if (configFilePath) {
     const content = readFileSync(configFilePath, { encoding: 'utf-8' });
     const configuration = loadConfiguration(content);

--- a/test/configuration/start.test.ts
+++ b/test/configuration/start.test.ts
@@ -81,6 +81,35 @@ describe('start with file configuration', () => {
       assert.deepStrictEqual(signals.profiling?.mock.callCount(), 1);
       assert.deepStrictEqual(signals.snapshots?.mock.callCount(), 1);
     });
+
+    it('should load the config file from OTEL_CONFIG_FILE', () => {
+      process.env.OTEL_CONFIG_FILE = exampleConfigPath();
+      process.env.SPLUNK_METRICS_ENABLED = 'false';
+      process.env.SPLUNK_PROFILER_ENABLED = 'false';
+      process.env.SPLUNK_TRACING_ENABLED = 'false';
+      process.env.SPLUNK_AUTOMATIC_LOG_COLLECTION = 'false';
+
+      start();
+
+      assert.deepStrictEqual(signals.tracing?.mock.callCount(), 1);
+      assert.deepStrictEqual(signals.metrics?.mock.callCount(), 1);
+      assert.deepStrictEqual(signals.logging?.mock.callCount(), 1);
+      assert.deepStrictEqual(signals.profiling?.mock.callCount(), 1);
+      assert.deepStrictEqual(signals.snapshots?.mock.callCount(), 1);
+    });
+
+    it('prefers OTEL_CONFIG_FILE over the deprecated OTEL_EXPERIMENTAL_CONFIG_FILE', () => {
+      process.env.OTEL_CONFIG_FILE = exampleConfigPath();
+      process.env.OTEL_EXPERIMENTAL_CONFIG_FILE = '/does/not/exist.yaml';
+      process.env.SPLUNK_METRICS_ENABLED = 'false';
+      process.env.SPLUNK_PROFILER_ENABLED = 'false';
+      process.env.SPLUNK_TRACING_ENABLED = 'false';
+      process.env.SPLUNK_AUTOMATIC_LOG_COLLECTION = 'false';
+
+      start();
+
+      assert.deepStrictEqual(signals.tracing?.mock.callCount(), 1);
+    });
   });
 
   describe('effective config gating', () => {

--- a/test/opamp/effective_config.test.ts
+++ b/test/opamp/effective_config.test.ts
@@ -572,13 +572,15 @@ distribution:
     });
 
     it('names the AgentConfigFile after the file actually loaded', () => {
-      // The distro loads OTEL_EXPERIMENTAL_CONFIG_FILE; the body must not be
-      // attributed to a different OTEL_CONFIG_FILE path that was never read.
-      process.env.OTEL_CONFIG_FILE = '/stable/never-loaded.yaml';
-      process.env.OTEL_EXPERIMENTAL_CONFIG_FILE = '/experimental/loaded.yaml';
+      // The distro prefers OTEL_CONFIG_FILE over the deprecated
+      // OTEL_EXPERIMENTAL_CONFIG_FILE; the body must not be attributed to the
+      // fallback path that was never read.
+      process.env.OTEL_CONFIG_FILE = '/stable/loaded.yaml';
+      process.env.OTEL_EXPERIMENTAL_CONFIG_FILE =
+        '/experimental/never-loaded.yaml';
 
       const config = loadAndReport('file_format: "1.0-rc.2"\n');
-      assert.strictEqual(config.name, '/experimental/loaded.yaml');
+      assert.strictEqual(config.name, '/stable/loaded.yaml');
     });
 
     it('reports every exporter when a signal has multiple processors', () => {


### PR DESCRIPTION
Environment variable was marked as stable in otel spec in the end of February: https://github.com/open-telemetry/opentelemetry-specification/commit/27094331af23ba915168c54cb503f13669464b4c
