### PR TITLE
OpAMP: Add snapshot selection probability to Effective & Remote config

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -48,6 +48,7 @@ import {
 import { AttributeValue } from '@opentelemetry/api';
 import { convertSubstitution, envSubstitute } from './configuration/substitute';
 import { getEffectiveState } from './opamp/effective-state';
+import { DEFAULT_SNAPSHOT_SELECTION_PROBABILITY } from './tracing/snapshots';
 
 type ConfigSampler = ConfigSchemaSampler;
 
@@ -761,6 +762,17 @@ function getEffectiveEnvironmentConfig(): string {
         getConfigNumber('SPLUNK_SNAPSHOT_PROFILER_SAMPLING_INTERVAL', 1),
     ],
     [
+      'SPLUNK_SNAPSHOT_SELECTION_PROBABILITY',
+      state.snapshotSelectionProbability ??
+        getConfigNumber(
+          [
+            'SPLUNK_SNAPSHOT_SELECTION_PROBABILITY',
+            'SPLUNK_SNAPSHOT_SELECTION_RATE',
+          ],
+          DEFAULT_SNAPSHOT_SELECTION_PROBABILITY
+        ),
+    ],
+    [
       'SPLUNK_PROFILER_CALL_STACK_INTERVAL',
       state.callStackInterval ??
         getConfigNumber('SPLUNK_PROFILER_CALL_STACK_INTERVAL', 1000),
@@ -994,6 +1006,10 @@ function projectProfiling(config: DistroConfiguration): object | undefined {
         state.snapshotSamplingInterval ??
         profiling?.callgraphs?.sampling_interval ??
         1,
+      selection_probability:
+        state.snapshotSelectionProbability ??
+        profiling?.callgraphs?.selection_probability ??
+        DEFAULT_SNAPSHOT_SELECTION_PROBABILITY,
     };
   }
 

--- a/src/opamp/OpAMPClient.ts
+++ b/src/opamp/OpAMPClient.ts
@@ -468,6 +468,10 @@ export class OpAMPClient {
           typeof callgraphs?.sampling_interval === 'number'
             ? callgraphs.sampling_interval
             : undefined,
+        selectionProbability:
+          typeof callgraphs?.selection_probability === 'number'
+            ? callgraphs.selection_probability
+            : undefined,
       },
     };
   }

--- a/src/opamp/effective-state.ts
+++ b/src/opamp/effective-state.ts
@@ -48,6 +48,7 @@ export interface EffectiveState {
   // Whether the snapshot profiler actually started.
   snapshotProfilerEnabled: boolean;
   snapshotSamplingInterval: number;
+  snapshotSelectionProbability: number;
 }
 
 let state: Partial<EffectiveState> = {};

--- a/src/opamp/types.ts
+++ b/src/opamp/types.ts
@@ -49,6 +49,8 @@ export interface RemoteProfilingConfig {
     enabled: boolean;
     // Sampling interval in milliseconds, when the server specified one.
     samplingInterval?: number;
+    // Probability of selecting a trace for snapshot profiling. Must be > 0 and <= 1.
+    selectionProbability?: number;
   };
 }
 

--- a/src/profiling/ProfilingController.ts
+++ b/src/profiling/ProfilingController.ts
@@ -225,6 +225,16 @@ export class ProfilingController {
   }
 
   private _applyCallgraphs(config: RemoteProfilingConfig): void {
+    const selectionProbability = config.callgraphs.selectionProbability;
+    if (
+      selectionProbability !== undefined &&
+      !(selectionProbability > 0 && selectionProbability <= 1)
+    ) {
+      throw new Error(
+        `callgraphs selection_probability ${selectionProbability} is out of range, it must be greater than 0 and at most 1`
+      );
+    }
+
     const requested = config.callgraphs.enabled;
     // A non-positive interval is invalid; pass undefined so the snapshot
     // profiler keeps its current interval rather than reconfiguring to 0.
@@ -234,18 +244,6 @@ export class ProfilingController {
         ? requestedInterval
         : undefined;
 
-    const requestedProbability = config.callgraphs.selectionProbability;
-    const validProbability =
-      requestedProbability === undefined ||
-      (requestedProbability > 0 && requestedProbability <= 1);
-    if (!validProbability) {
-      diag.warn(
-        `opamp: ignoring callgraphs selection_probability ${requestedProbability}, it must be greater than 0 and at most 1`
-      );
-    }
-    const selectionProbability = validProbability
-      ? requestedProbability
-      : undefined;
     const probabilityApplied =
       setSnapshotSelectionProbability(selectionProbability);
 

--- a/src/profiling/ProfilingController.ts
+++ b/src/profiling/ProfilingController.ts
@@ -18,7 +18,10 @@ import { diag } from '@opentelemetry/api';
 import { startProfiling } from './index';
 import type { ProfilingOptions } from './types';
 import { recordEffectiveState } from '../opamp/effective-state';
-import { setSnapshotProfilingActive } from '../tracing/snapshots/Snapshots';
+import {
+  setSnapshotProfilingActive,
+  setSnapshotSelectionProbability,
+} from '../tracing/snapshots/Snapshots';
 import type { RemoteProfilingConfig } from '../opamp/types';
 
 // Tracks a currently-running always-on profiler so applyRemoteConfiguration() can decide between a
@@ -50,6 +53,9 @@ export class ProfilingController {
   // reconfigures/logs only on an actual change. Undefined until a config sets
   // one (the snapshot profiler keeps its startup default in the meantime).
   private _callgraphsSamplingInterval: number | undefined;
+  // Last callgraphs selection probability applied via remote config. Undefined
+  // means the startup-configured probability is in effect.
+  private _callgraphsSelectionProbability: number | undefined;
 
   constructor(baseOptions: ProfilingOptions) {
     this._baseOptions = baseOptions;
@@ -228,6 +234,21 @@ export class ProfilingController {
         ? requestedInterval
         : undefined;
 
+    const requestedProbability = config.callgraphs.selectionProbability;
+    const validProbability =
+      requestedProbability === undefined ||
+      (requestedProbability > 0 && requestedProbability <= 1);
+    if (!validProbability) {
+      diag.warn(
+        `opamp: ignoring callgraphs selection_probability ${requestedProbability}, it must be greater than 0 and at most 1`
+      );
+    }
+    const selectionProbability = validProbability
+      ? requestedProbability
+      : undefined;
+    const probabilityApplied =
+      setSnapshotSelectionProbability(selectionProbability);
+
     const effective = setSnapshotProfilingActive(requested, samplingInterval);
 
     // setSnapshotProfilingActive returns the state it could actually reach: it
@@ -249,17 +270,34 @@ export class ProfilingController {
       this._callgraphsSamplingInterval = samplingInterval;
     }
 
+    const probabilityChanged =
+      probabilityApplied &&
+      selectionProbability !== this._callgraphsSelectionProbability;
+    if (probabilityChanged) {
+      this._callgraphsSelectionProbability = selectionProbability;
+    }
+
+    const settings: string[] = [];
+    if (samplingInterval !== undefined) {
+      settings.push(`sampling interval ${samplingInterval}ms`);
+    }
+    if (selectionProbability !== undefined) {
+      settings.push(`selection probability ${selectionProbability}`);
+    } else if (probabilityChanged) {
+      settings.push('default selection probability');
+    }
+    const describedSettings =
+      settings.length > 0 ? ` (${settings.join(', ')})` : '';
+
     if (effective !== this._callgraphsActive) {
       this._callgraphsActive = effective;
       diag.info(
         `opamp: remote config ${effective ? 'enabled' : 'disabled'} callgraphs (snapshot profiling)` +
-          (effective && samplingInterval !== undefined
-            ? ` (sampling interval ${samplingInterval}ms)`
-            : '')
+          (effective ? describedSettings : '')
       );
-    } else if (intervalChanged) {
+    } else if (intervalChanged || probabilityChanged) {
       diag.info(
-        `opamp: remote config reconfigured callgraphs sampling interval to ${samplingInterval}ms`
+        `opamp: remote config reconfigured callgraphs${describedSettings}`
       );
     }
   }

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -37,9 +37,14 @@ import type { StartTracingOptions, TracingOptions } from './types';
 import { isProfilingContextManagerSet } from '../profiling';
 import {
   isSnapshotProfilingActive,
+  registerSnapshotPropagator,
   snapshotSpanProcessor,
+  unregisterSnapshotPropagator,
 } from './snapshots/Snapshots';
-import { SnapshotPropagator } from './snapshots';
+import {
+  DEFAULT_SNAPSHOT_SELECTION_PROBABILITY,
+  SnapshotPropagator,
+} from './snapshots';
 import { CompositePropagator } from '@opentelemetry/core';
 import { getConfigNumber } from '../configuration';
 
@@ -97,23 +102,23 @@ export function startTracing(options: TracingOptions): boolean {
   // even an inactive one pre-registered for remote config: trace selection must
   // happen at span creation so callgraphs can be toggled on later.
   if (snapshotSpanProcessor() !== undefined) {
+    const snapshotPropagator = new SnapshotPropagator(
+      getConfigNumber(
+        [
+          'SPLUNK_SNAPSHOT_SELECTION_PROBABILITY',
+          'SPLUNK_SNAPSHOT_SELECTION_RATE',
+        ],
+        DEFAULT_SNAPSHOT_SELECTION_PROBABILITY
+      ),
+      // Only originate/observe snapshot-volume baggage while the profiler is
+      // actually collecting, not merely registered (it may be pre-registered
+      // inactive for remote config and never enabled).
+      isSnapshotProfilingActive
+    );
+    registerSnapshotPropagator(snapshotPropagator);
+
     propagator = new CompositePropagator({
-      propagators: [
-        propagator,
-        new SnapshotPropagator(
-          getConfigNumber(
-            [
-              'SPLUNK_SNAPSHOT_SELECTION_PROBABILITY',
-              'SPLUNK_SNAPSHOT_SELECTION_RATE',
-            ],
-            0.01
-          ),
-          // Only originate/observe snapshot-volume baggage while the profiler is
-          // actually collecting, not merely registered (it may be pre-registered
-          // inactive for remote config and never enabled).
-          isSnapshotProfilingActive
-        ),
-      ],
+      propagators: [propagator, snapshotPropagator],
     });
   }
   propagation.setGlobalPropagator(propagator);
@@ -174,6 +179,7 @@ export async function stopTracing() {
   // mostly for tests.
   unregisterInstrumentations?.();
   unregisterInstrumentations = null;
+  unregisterSnapshotPropagator();
 
   const shutdownPromise = shutdownGlobalTracerProvider();
 

--- a/src/tracing/snapshots/SnapshotPropagator.ts
+++ b/src/tracing/snapshots/SnapshotPropagator.ts
@@ -28,6 +28,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 
 export const VOLUME_BAGGAGE_KEY = 'splunk.trace.snapshot.volume' as const;
+export const DEFAULT_SNAPSHOT_SELECTION_PROBABILITY = 0.01;
 
 function withVolumeBaggage(context: Context, isSelected: boolean) {
   let baggage = propagation.getBaggage(context);
@@ -56,11 +57,26 @@ export class SnapshotPropagator implements TextMapPropagator<unknown> {
   // decisions. Injected rather than imported so the propagator stays decoupled
   // from the snapshot profiler module.
   private _isActive: () => boolean;
+  // The startup-configured rate, restored when remote config enables snapshot
+  // profiling without specifying a selection probability.
+  private readonly _startupSelectionRate: number;
 
   constructor(selectionRate: number, isActive: () => boolean = () => true) {
     this.selectionRate = normalizeRate(selectionRate);
+    this._startupSelectionRate = this.selectionRate;
     this.sampler = new TraceIdRatioBasedSampler(this.selectionRate);
     this._isActive = isActive;
+  }
+
+  setSelectionRate(selectionRate: number | undefined) {
+    const rate = normalizeRate(selectionRate ?? this._startupSelectionRate);
+
+    if (rate === this.selectionRate) {
+      return;
+    }
+
+    this.selectionRate = rate;
+    this.sampler = new TraceIdRatioBasedSampler(rate);
   }
 
   inject(

--- a/src/tracing/snapshots/Snapshots.ts
+++ b/src/tracing/snapshots/Snapshots.ts
@@ -17,6 +17,7 @@ import { Resource } from '@opentelemetry/resources';
 import { ensureProfilingContextManager, noopExtension } from '../../profiling';
 import { getConfigBoolean, getConfigNumber } from '../../configuration';
 import { SnapshotSpanProcessor } from './SnapshotSpanProcessor';
+import type { SnapshotPropagator } from './SnapshotPropagator';
 import type { CpuProfile, ProfilingExtension } from '../../profiling/types';
 import { OtlpHttpProfilingExporter } from '../../profiling/OtlpHttpProfilingExporter';
 import { loadExtension } from '../../profiling';
@@ -246,6 +247,7 @@ export class SnapshotProfiler {
 }
 
 let profiler: SnapshotProfiler | undefined;
+let snapshotPropagator: SnapshotPropagator | undefined;
 
 export function startSnapshotProfiling(options: StartSnapshotProfilingOptions) {
   const samplingIntervalMs =
@@ -311,6 +313,29 @@ export function setSnapshotProfilingActive(
 
   recordEffectiveState({ snapshotProfilerEnabled: effective });
   return effective;
+}
+
+export function registerSnapshotPropagator(p: SnapshotPropagator) {
+  snapshotPropagator = p;
+  recordEffectiveState({ snapshotSelectionProbability: p.selectionRate });
+}
+
+export function unregisterSnapshotPropagator() {
+  snapshotPropagator = undefined;
+}
+
+export function setSnapshotSelectionProbability(
+  probability: number | undefined
+): boolean {
+  if (!snapshotPropagator) {
+    return false;
+  }
+
+  snapshotPropagator.setSelectionRate(probability);
+  recordEffectiveState({
+    snapshotSelectionProbability: snapshotPropagator.selectionRate,
+  });
+  return true;
 }
 
 export async function stopSnapshotProfiling() {

--- a/src/tracing/snapshots/index.ts
+++ b/src/tracing/snapshots/index.ts
@@ -13,4 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { SnapshotPropagator } from './SnapshotPropagator';
+export {
+  DEFAULT_SNAPSHOT_SELECTION_PROBABILITY,
+  SnapshotPropagator,
+} from './SnapshotPropagator';

--- a/test/opamp/effective_config.test.ts
+++ b/test/opamp/effective_config.test.ts
@@ -46,6 +46,7 @@ const REQUIRED_ENV_KEYS = [
   'SPLUNK_PROFILER_MEMORY_ENABLED',
   'SPLUNK_SNAPSHOT_PROFILER_ENABLED',
   'SPLUNK_SNAPSHOT_PROFILER_SAMPLING_INTERVAL',
+  'SPLUNK_SNAPSHOT_SELECTION_PROBABILITY',
   'SPLUNK_PROFILER_CALL_STACK_INTERVAL',
   'OTEL_CONFIG_FILE',
   'OTEL_EXPERIMENTAL_CONFIG_FILE',
@@ -92,6 +93,10 @@ describe('EffectiveConfig', () => {
       assert.strictEqual(
         map.get('SPLUNK_SNAPSHOT_PROFILER_SAMPLING_INTERVAL'),
         '1'
+      );
+      assert.strictEqual(
+        map.get('SPLUNK_SNAPSHOT_SELECTION_PROBABILITY'),
+        '0.01'
       );
       assert.strictEqual(
         map.get('SPLUNK_PROFILER_CALL_STACK_INTERVAL'),
@@ -168,6 +173,29 @@ describe('EffectiveConfig', () => {
         '9999'
       );
       assert.strictEqual(map.get('SPLUNK_PROFILER_MEMORY_ENABLED'), 'true');
+    });
+
+    it('reports a selection probability changed at runtime', () => {
+      process.env.SPLUNK_SNAPSHOT_SELECTION_PROBABILITY = '0.02';
+      // Remote config can change the probability after startup; the report must
+      // reflect the value actually in use, not the one from the environment.
+      recordEffectiveState({ snapshotSelectionProbability: 0.5 });
+
+      const map = parseEnvBody(getLoadedConfigurationString().content);
+      assert.strictEqual(
+        map.get('SPLUNK_SNAPSHOT_SELECTION_PROBABILITY'),
+        '0.5'
+      );
+    });
+
+    it('reports the configured selection probability when unchanged', () => {
+      process.env.SPLUNK_SNAPSHOT_SELECTION_PROBABILITY = '0.02';
+
+      const map = parseEnvBody(getLoadedConfigurationString().content);
+      assert.strictEqual(
+        map.get('SPLUNK_SNAPSHOT_SELECTION_PROBABILITY'),
+        '0.02'
+      );
     });
 
     it('reports the profiler as disabled when it failed to start', () => {
@@ -446,6 +474,20 @@ distribution:
       );
     });
 
+    it('reports callgraphs.selection_probability when configured', () => {
+      const config = loadAndReport(
+        'file_format: "1.0-rc.2"\ndistribution:\n  splunk:\n' +
+          '    profiling:\n      callgraphs:\n        sampling_interval: 10\n' +
+          '        selection_probability: 0.25\n'
+      );
+
+      const body = parseYaml(config.content);
+      assert.strictEqual(
+        body.distribution.splunk.profiling.callgraphs.selection_probability,
+        0.25
+      );
+    });
+
     it('reports a bare callgraphs block as enabled with the default interval', () => {
       // A bare `callgraphs:` parses as null but the runtime enables snapshots
       // (SPLUNK_SNAPSHOT_PROFILER_ENABLED derives from callgraphs !== undefined),
@@ -459,6 +501,10 @@ distribution:
       assert.strictEqual(
         body.distribution.splunk.profiling.callgraphs.sampling_interval,
         1
+      );
+      assert.strictEqual(
+        body.distribution.splunk.profiling.callgraphs.selection_probability,
+        0.01
       );
     });
 

--- a/test/opamp/remote_config.test.ts
+++ b/test/opamp/remote_config.test.ts
@@ -155,7 +155,11 @@ describe('OpAMP remote config', () => {
       assert.deepStrictEqual(applied, {
         cpuProfiler: { enabled: true, samplingInterval: 250 },
         memoryProfiler: { enabled: false },
-        callgraphs: { enabled: false, samplingInterval: undefined },
+        callgraphs: {
+          enabled: false,
+          samplingInterval: undefined,
+          selectionProbability: undefined,
+        },
       });
     });
 
@@ -184,6 +188,61 @@ describe('OpAMP remote config', () => {
       assert(applied);
       assert.strictEqual(applied.callgraphs.enabled, true);
       assert.strictEqual(applied.callgraphs.samplingInterval, 5);
+    });
+
+    it('parses a callgraphs selection probability', async () => {
+      let applied: RemoteProfilingConfig | undefined;
+      const client = new OpAMPClient(
+        createOptions({
+          applyRemoteConfig: async (cfg) => {
+            applied = cfg;
+          },
+        }),
+        createMockTransport()
+      );
+
+      const body = [
+        'distribution:',
+        '  splunk:',
+        '    profiling:',
+        '      callgraphs:',
+        '        sampling_interval: 10',
+        '        selection_probability: 0.5',
+      ].join('\n');
+
+      client.processServerResponse(remoteConfigResponse({ body }));
+      await waitForApply();
+
+      assert(applied);
+      assert.strictEqual(applied.callgraphs.enabled, true);
+      assert.strictEqual(applied.callgraphs.selectionProbability, 0.5);
+    });
+
+    it('ignores a non-numeric callgraphs selection probability', async () => {
+      let applied: RemoteProfilingConfig | undefined;
+      const client = new OpAMPClient(
+        createOptions({
+          applyRemoteConfig: async (cfg) => {
+            applied = cfg;
+          },
+        }),
+        createMockTransport()
+      );
+
+      const body = [
+        'distribution:',
+        '  splunk:',
+        '    profiling:',
+        '      callgraphs:',
+        '        selection_probability: "half"',
+      ].join('\n');
+
+      client.processServerResponse(remoteConfigResponse({ body }));
+      await waitForApply();
+
+      assert(applied);
+      assert.strictEqual(applied.callgraphs.enabled, true);
+      assert.strictEqual(applied.callgraphs.selectionProbability, undefined);
     });
 
     it('treats a bare cpu_profiler key as enabled with no interval', async () => {

--- a/test/profiling/profiling_controller.test.ts
+++ b/test/profiling/profiling_controller.test.ts
@@ -55,6 +55,7 @@ function remoteConfig(
     memory: boolean;
     callgraphs: boolean;
     callgraphsInterval?: number;
+    callgraphsProbability?: number;
   }> = {}
 ): RemoteProfilingConfig {
   return {
@@ -66,6 +67,7 @@ function remoteConfig(
     callgraphs: {
       enabled: overrides.callgraphs ?? false,
       samplingInterval: overrides.callgraphsInterval,
+      selectionProbability: overrides.callgraphsProbability,
     },
   };
 }
@@ -80,11 +82,15 @@ interface ActiveCall {
 describe('ProfilingController', () => {
   let startCalls: StartCall[];
   let activeCalls: ActiveCall[];
+  // Each probability the controller forwarded to the propagator; undefined means
+  // "restore the startup-configured probability".
+  let probabilityCalls: (number | undefined)[];
 
   beforeEach(() => {
     resetEffectiveState();
     startCalls = [];
     activeCalls = [];
+    probabilityCalls = [];
 
     mock.method(
       profilingIndex,
@@ -106,6 +112,15 @@ describe('ProfilingController', () => {
       (active: boolean, samplingIntervalMs?: number) => {
         activeCalls.push({ active, samplingIntervalMs });
         return active;
+      }
+    );
+
+    mock.method(
+      snapshots,
+      'setSnapshotSelectionProbability',
+      (probability?: number) => {
+        probabilityCalls.push(probability);
+        return true;
       }
     );
   });
@@ -374,6 +389,48 @@ describe('ProfilingController', () => {
       assert.deepStrictEqual(activeCalls, [
         { active: true, samplingIntervalMs: undefined },
       ]);
+    });
+
+    it('forwards the selection probability when enabling callgraphs', async () => {
+      const controller = new ProfilingController(BASE_OPTIONS);
+      controller.startInitial(false);
+
+      await controller.applyRemoteConfiguration(
+        remoteConfig({ callgraphs: true, callgraphsProbability: 0.5 })
+      );
+
+      assert.deepStrictEqual(probabilityCalls, [0.5]);
+    });
+
+    it('restores the default probability when the config omits it', async () => {
+      const controller = new ProfilingController(BASE_OPTIONS);
+      controller.startInitial(false);
+
+      await controller.applyRemoteConfiguration(
+        remoteConfig({ callgraphs: true, callgraphsProbability: 0.5 })
+      );
+      // The accepted remote config is authoritative: without a probability the
+      // propagator goes back to its startup-configured value.
+      await controller.applyRemoteConfiguration(
+        remoteConfig({ callgraphs: true })
+      );
+
+      assert.deepStrictEqual(probabilityCalls, [0.5, undefined]);
+    });
+
+    it('ignores an out-of-range selection probability', async () => {
+      const controller = new ProfilingController(BASE_OPTIONS);
+      controller.startInitial(false);
+
+      // Per the GDI datamodel the probability must be > 0 and <= 1.
+      await controller.applyRemoteConfiguration(
+        remoteConfig({ callgraphs: true, callgraphsProbability: 0 })
+      );
+      await controller.applyRemoteConfiguration(
+        remoteConfig({ callgraphs: true, callgraphsProbability: 1.5 })
+      );
+
+      assert.deepStrictEqual(probabilityCalls, [undefined, undefined]);
     });
   });
 

--- a/test/profiling/profiling_controller.test.ts
+++ b/test/profiling/profiling_controller.test.ts
@@ -418,19 +418,50 @@ describe('ProfilingController', () => {
       assert.deepStrictEqual(probabilityCalls, [0.5, undefined]);
     });
 
-    it('ignores an out-of-range selection probability', async () => {
+    it('rejects an out-of-range selection probability', async () => {
       const controller = new ProfilingController(BASE_OPTIONS);
       controller.startInitial(false);
 
-      // Per the GDI datamodel the probability must be > 0 and <= 1.
-      await controller.applyRemoteConfiguration(
-        remoteConfig({ callgraphs: true, callgraphsProbability: 0 })
+      // Per the GDI datamodel the probability must be greater than 0 and at most
+      // 1. Such a config is rejected (OpAMP reports FAILED) and nothing is
+      // applied: coercing the value to "omitted" would restore the startup
+      // probability and silently change trace selection.
+      await assert.rejects(
+        controller.applyRemoteConfiguration(
+          remoteConfig({ callgraphs: true, callgraphsProbability: 0 })
+        ),
+        /selection_probability 0 is out of range/
       );
-      await controller.applyRemoteConfiguration(
-        remoteConfig({ callgraphs: true, callgraphsProbability: 1.5 })
+      await assert.rejects(
+        controller.applyRemoteConfiguration(
+          remoteConfig({ callgraphs: true, callgraphsProbability: 1.5 })
+        ),
+        /selection_probability 1.5 is out of range/
       );
 
-      assert.deepStrictEqual(probabilityCalls, [undefined, undefined]);
+      assert.deepStrictEqual(probabilityCalls, []);
+      assert.deepStrictEqual(activeCalls, []);
+    });
+
+    it('still applies cpu config when the selection probability is rejected', async () => {
+      const controller = new ProfilingController(BASE_OPTIONS);
+      controller.startInitial(false);
+
+      // The two halves are applied independently, so a rejected callgraphs block
+      // must not drop a valid cpu_profiler change.
+      await assert.rejects(
+        controller.applyRemoteConfiguration(
+          remoteConfig({
+            cpu: true,
+            samplingInterval: 250,
+            callgraphs: true,
+            callgraphsProbability: 2,
+          })
+        )
+      );
+
+      assert.strictEqual(startCalls.length, 1);
+      assert.strictEqual(startCalls[0].callstackInterval, 250);
     });
   });
 

--- a/test/snapshots/snapshot_propagator.test.ts
+++ b/test/snapshots/snapshot_propagator.test.ts
@@ -174,4 +174,26 @@ describe('snapshot propagator', () => {
       'context is passed through unchanged'
     );
   });
+
+  it('selects traces at a probability set at runtime', () => {
+    // Remote config can change the selection probability after startup.
+    const propagator = new SnapshotPropagator(0.0);
+
+    propagator.setSelectionRate(1.0);
+    const selected = propagation.getBaggage(
+      propagator.extract(ROOT_CONTEXT, undefined, NoopGetter)
+    );
+    assert.strictEqual(
+      selected?.getEntry(VOLUME_BAGGAGE_KEY)?.value,
+      'highest'
+    );
+
+    // Omitting a probability means "the default", i.e. the rate the propagator
+    // was constructed with.
+    propagator.setSelectionRate(undefined);
+    const notSelected = propagation.getBaggage(
+      propagator.extract(ROOT_CONTEXT, undefined, NoopGetter)
+    );
+    assert.strictEqual(notSelected?.getEntry(VOLUME_BAGGAGE_KEY)?.value, 'off');
+  });
 });


### PR DESCRIPTION
See gdi-specification changes:

* [EffectiveConfig] Add Support for Selection Probability https://github.com/signalfx/gdi-specification/commit/b5832cdfe198dae656976dd9fc1ff015d2276d0f
* [RemoteConfig] Add Support for Callgraphs https://github.com/signalfx/gdi-specification/commit/5600eef739d522afda1a0058808d8b0be829ae3a

Added:

* Reporting current selection probability in effective config
* Applying `callgraphs.selection_probability` in remote config