### PR TITLE
fix: use buildSamplerFromEnv

### DIFF
--- a/src/tracing/options.ts
+++ b/src/tracing/options.ts
@@ -21,6 +21,7 @@ import {
   SpanExporter,
   SpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
+import { buildSamplerFromEnv } from '@opentelemetry/sdk-trace-base/build/src/config';
 import { createRuleBasedSampler } from './RuleBasedSampler';
 import { B3Propagator, B3InjectEncoding } from '@opentelemetry/propagator-b3';
 import { AWSXRayPropagator } from '@opentelemetry/propagator-aws-xray';
@@ -92,6 +93,8 @@ function createSampler(userConfig: NodeTracerConfig) {
         getNonEmptyEnvVar('OTEL_TRACES_SAMPLER_ARG')
       );
     }
+
+    return buildSamplerFromEnv();
   }
 
   return configSampler;

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -42,6 +42,7 @@ import {
   SpanExporter,
   InMemorySpanExporter,
   AlwaysOffSampler,
+  TraceIdRatioBasedSampler,
 } from '@opentelemetry/sdk-trace-base';
 
 import { strict as assert } from 'assert';
@@ -272,6 +273,27 @@ describe('options', () => {
       'v9001'
     );
     assert.strictEqual(options.tracerConfig.resource?.attributes['abc'], 42);
+  });
+
+  describe('OTEL_TRACES_SAMPLER', () => {
+    it('uses a standard sampler from the environment', () => {
+      process.env.OTEL_TRACES_SAMPLER = 'always_off';
+
+      const options = _setDefaultOptions();
+
+      assert.ok(options.tracerConfig.sampler instanceof AlwaysOffSampler);
+    });
+
+    it('passes the sampler argument to a standard sampler', () => {
+      process.env.OTEL_TRACES_SAMPLER = 'traceidratio';
+      process.env.OTEL_TRACES_SAMPLER_ARG = '0.25';
+
+      const options = _setDefaultOptions();
+      const sampler = options.tracerConfig.sampler;
+
+      assert.ok(sampler instanceof TraceIdRatioBasedSampler);
+      assert.equal(sampler['_ratio'], 0.25);
+    });
   });
 
   describe('OTEL_TRACES_EXPORTER', () => {

--- a/test/tracing/env_options.test.ts
+++ b/test/tracing/env_options.test.ts
@@ -20,10 +20,10 @@ import { assertTracingPipeline } from './common';
 
 import { parseOptionsAndConfigureInstrumentations } from '../../src/instrumentations';
 import { startTracing, stopTracing } from '../../src/tracing';
-import { trace } from '@opentelemetry/api';
-import { ParentBasedSampler } from '@opentelemetry/sdk-trace-base';
+import { context, trace, TraceFlags } from '@opentelemetry/api';
+import { TraceIdRatioBasedSampler } from '@opentelemetry/sdk-trace-base';
 
-test('Tracing: set up with env options', async () => {
+test('Tracing: honors standard sampler env options', async () => {
   const url = 'url-from-env:3030';
   const serviceName = 'env-service';
   const accessToken = 'zxcvb';
@@ -31,14 +31,30 @@ test('Tracing: set up with env options', async () => {
   process.env.OTEL_EXPORTER_OTLP_ENDPOINT = url;
   process.env.OTEL_SERVICE_NAME = serviceName;
   process.env.SPLUNK_ACCESS_TOKEN = accessToken;
-  process.env.OTEL_TRACES_SAMPLER = 'parentbased_always_on';
+  process.env.OTEL_TRACES_SAMPLER = 'traceidratio';
+  process.env.OTEL_TRACES_SAMPLER_ARG = '1.0';
 
   const { tracingOptions } = parseOptionsAndConfigureInstrumentations();
   startTracing(tracingOptions);
   await assertTracingPipeline(`${url}/v1/traces`, serviceName, accessToken);
 
   const provider = trace.getTracerProvider();
-  assert(provider.getTracer('test')['_sampler'] instanceof ParentBasedSampler);
+  assert(
+    provider.getTracer('test')['_sampler'] instanceof TraceIdRatioBasedSampler
+  );
+
+  const unsampledRemoteParent = trace.setSpanContext(context.active(), {
+    traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+    spanId: '00f067aa0ba902b7',
+    traceFlags: TraceFlags.NONE,
+    isRemote: true,
+  });
+  const span = trace
+    .getTracer('test')
+    .startSpan('child', {}, unsampledRemoteParent);
+
+  assert.equal(span.spanContext().traceFlags & TraceFlags.SAMPLED, 1);
+  span.end();
 
   await stopTracing();
 });


### PR DESCRIPTION
`createSampler` now delegates to the OTel SDK's `buildSamplerFromEnv`. In version `2.9.0` of the SDK changed the default sampler building.

Fixes https://github.com/signalfx/splunk-otel-js/issues/1180