### PR TITLE
chore: release v4.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log - @splunk/otel
 
+## 4.11.0
+
+- OpAMP: add snapshot selection probability. [#1179](https://github.com/signalfx/splunk-otel-js/pull/1179)
+- Upgrade to OpenTelemetry 2.10.0 / 0.221.0. [#1181](https://github.com/signalfx/splunk-otel-js/pull/1181)
+  - OTel moved to stable semantic conventions, thus a few attribute names have now changed.
+    See https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/
+    and https://opentelemetry.io/docs/specs/semconv/non-normative/db-migration/
+    for the changed attribute names.
+- Fix `OTEL_TRACES_SAMPLER` env var not building samplers correctly. The error
+  was introduced with `4.10.0`. Fixes [#1180](https://github.com/signalfx/splunk-otel-js/issues/1180). [#1182](https://github.com/signalfx/splunk-otel-js/pull/1182)
+
 ## 4.10.0
 
 - Upgrade to OpenTelemetry 2.9.0 / 0.220.0. [#1175](https://github.com/signalfx/splunk-otel-js/pull/1175)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@splunk/otel",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "dev": true,
   "packages": {
     "": {
       "name": "@splunk/otel",
-      "version": "4.10.0",
+      "version": "4.11.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "The Splunk distribution of OpenTelemetry Node Instrumentation provides a Node agent that automatically instruments your Node application to capture and report distributed traces to Splunk APM.",
   "keywords": [
     "apm",

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const VERSION = '4.10.0';
+export const VERSION = '4.11.0';


### PR DESCRIPTION
- OpAMP: add snapshot selection probability. [#1179](https://github.com/signalfx/splunk-otel-js/pull/1179)
- Upgrade to OpenTelemetry 2.10.0 / 0.221.0. [#1181](https://github.com/signalfx/splunk-otel-js/pull/1181)
  - OTel moved to stable semantic conventions, thus a few attribute names have now changed.
    See https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/
    and https://opentelemetry.io/docs/specs/semconv/non-normative/db-migration/
    for the changed attribute names.
- Fix `OTEL_TRACES_SAMPLER` env var not building samplers correctly. The error
  was introduced with `4.10.0`. Fixes [#1180](https://github.com/signalfx/splunk-otel-js/issues/1180). [#1182](https://github.com/signalfx/splunk-otel-js/pull/1182)