### PR TITLE
feat: add couchbase adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ By default, the following instrumentations are active:
 * [`@opentelemetry/instrumentation-typeorm`](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-typeorm)
 * [`@opentelemetry/instrumentation-undici`](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-undici)
 * [`@opentelemetry/instrumentation-winston`](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-winston)
+* [`splunk-opentelemetry-instrumentation-couchbase`](https://github.com/signalfx/splunk-otel-js/tree/main/src/instrumentations/external/couchbase) (Couchbase SDK 4.7+)
 * [`splunk-opentelemetry-instrumentation-elasticsearch`](https://github.com/signalfx/splunk-otel-js/tree/main/src/instrumentations/external/elasticsearch)
 * [`splunk-opentelemetry-instrumentation-neo4j`](https://github.com/signalfx/splunk-otel-js/tree/main/src/instrumentations/external/neo4j)
 

--- a/scripts/generate-metadata-yaml.js
+++ b/scripts/generate-metadata-yaml.js
@@ -6,6 +6,7 @@ const { getInstrumentations } = require('../lib/instrumentations');
 const LOADED_INSTRUMENTATIONS = getInstrumentations();
 
 const KNOWN_TARGET_LIBRARY_VERSIONS = new Map([
+  ['splunk-opentelemetry-instrumentation-couchbase', ['>=4.7.0 <5']],
   ['splunk-opentelemetry-instrumentation-elasticsearch', ['>=5 <8']],
   ['splunk-opentelemetry-instrumentation-kafkajs', ['>=0.1.0 <3']],
   ['splunk-opentelemetry-instrumentation-sequelize', ['*']],
@@ -76,6 +77,11 @@ const INSTRUMENTATIONS = [
   { name: '@opentelemetry/instrumentation-tedious', target: 'tedious' },
   { name: '@opentelemetry/instrumentation-undici', target: 'undici' },
   { name: '@opentelemetry/instrumentation-winston', target: 'winston' },
+  {
+    name: 'splunk-opentelemetry-instrumentation-couchbase',
+    target: 'couchbase',
+    support: 'supported',
+  },
   {
     name: 'splunk-opentelemetry-instrumentation-elasticsearch',
     target: '@elastic/elasticsearch',

--- a/src/instrumentations/external/couchbase/couchbase.ts
+++ b/src/instrumentations/external/couchbase/couchbase.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  InstrumentationBase,
+  InstrumentationModuleDefinition,
+  InstrumentationNodeModuleDefinition,
+  isWrapped,
+} from '@opentelemetry/instrumentation';
+import { getConfigBoolean } from '../../../configuration';
+import { VERSION } from '../../../version';
+
+type CouchbaseConnect = (...args: unknown[]) => unknown;
+
+interface CouchbaseConnectTarget {
+  connect: CouchbaseConnect;
+}
+
+interface CouchbaseConnectOptions {
+  tracer?: unknown;
+  meter?: unknown;
+  tracingConfig?: {
+    enableTracing?: boolean;
+  };
+  metricsConfig?: {
+    enableMetrics?: boolean;
+  };
+  [key: string]: unknown;
+}
+
+interface CouchbaseModule extends CouchbaseConnectTarget {
+  Cluster?: CouchbaseConnectTarget;
+  getOTelTracer: () => unknown;
+  getOTelMeter?: () => unknown;
+}
+
+export class CouchbaseInstrumentation extends InstrumentationBase {
+  constructor() {
+    super('splunk-opentelemetry-instrumentation-couchbase', VERSION, {});
+  }
+
+  protected init(): InstrumentationModuleDefinition {
+    return new InstrumentationNodeModuleDefinition(
+      'couchbase',
+      ['>=4.7.0 <5'],
+      (moduleExports: CouchbaseModule, moduleVersion) => {
+        this._diag.debug(
+          `couchbase instrumentation: patch couchbase ${moduleVersion ?? ''}`
+        );
+        this.patchConnect(moduleExports, moduleExports);
+        if (moduleExports.Cluster) {
+          this.patchConnect(moduleExports, moduleExports.Cluster);
+        }
+        return moduleExports;
+      },
+      (moduleExports: CouchbaseModule) => {
+        this._diag.debug('couchbase instrumentation: unpatch couchbase');
+        this.unpatchConnect(moduleExports);
+        if (moduleExports.Cluster) {
+          this.unpatchConnect(moduleExports.Cluster);
+        }
+      }
+    );
+  }
+
+  private patchConnect(
+    moduleExports: CouchbaseModule,
+    target: CouchbaseConnectTarget
+  ): void {
+    if (isWrapped(target.connect)) {
+      this._unwrap(target, 'connect');
+    }
+
+    const instrumentation = this;
+    this._wrap(target, 'connect', (originalConnect) => {
+      return function (this: unknown, ...args: unknown[]) {
+        const connectArgs = instrumentation.injectTelemetry(
+          moduleExports,
+          args
+        );
+        return originalConnect.apply(this, connectArgs);
+      };
+    });
+  }
+
+  private unpatchConnect(target: CouchbaseConnectTarget): void {
+    if (isWrapped(target.connect)) {
+      this._unwrap(target, 'connect');
+    }
+  }
+
+  private injectTelemetry(
+    moduleExports: CouchbaseModule,
+    args: unknown[]
+  ): unknown[] {
+    const suppliedOptions = args[1];
+    if (
+      suppliedOptions !== undefined &&
+      (suppliedOptions === null || typeof suppliedOptions !== 'object')
+    ) {
+      return args;
+    }
+
+    const options = (suppliedOptions ?? {}) as CouchbaseConnectOptions;
+    const injectTracer =
+      options.tracer === undefined &&
+      options.tracingConfig?.enableTracing !== false;
+    const injectMeter =
+      getConfigBoolean('SPLUNK_INSTRUMENTATION_METRICS_ENABLED', false) &&
+      options.meter === undefined &&
+      options.metricsConfig?.enableMetrics !== false &&
+      moduleExports.getOTelMeter !== undefined;
+
+    if (!injectTracer && !injectMeter) {
+      return args;
+    }
+
+    const connectArgs = [...args];
+    const injectedOptions = { ...options };
+
+    if (injectTracer) {
+      injectedOptions.tracer = moduleExports.getOTelTracer();
+    }
+    if (injectMeter) {
+      injectedOptions.meter = moduleExports.getOTelMeter?.();
+    }
+
+    connectArgs[1] = injectedOptions;
+    return connectArgs;
+  }
+}

--- a/src/instrumentations/external/couchbase/index.ts
+++ b/src/instrumentations/external/couchbase/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { CouchbaseInstrumentation } from './couchbase';

--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -41,6 +41,7 @@ import { AmqplibInstrumentation } from '@opentelemetry/instrumentation-amqplib';
 import { AwsInstrumentation } from '@opentelemetry/instrumentation-aws-sdk';
 import { BunyanInstrumentation } from '@opentelemetry/instrumentation-bunyan';
 import { CassandraDriverInstrumentation } from '@opentelemetry/instrumentation-cassandra-driver';
+import { CouchbaseInstrumentation } from './external/couchbase';
 import { ConnectInstrumentation } from '@opentelemetry/instrumentation-connect';
 import { DataloaderInstrumentation } from '@opentelemetry/instrumentation-dataloader';
 import { DnsInstrumentation } from '@opentelemetry/instrumentation-dns';
@@ -108,6 +109,10 @@ export const bundledInstrumentations: InstrumentationInfo[] = [
   {
     create: () => new CassandraDriverInstrumentation(),
     shortName: 'cassandra_driver',
+  },
+  {
+    create: () => new CouchbaseInstrumentation(),
+    shortName: 'couchbase',
   },
   {
     create: () => new ConnectInstrumentation(),

--- a/test/instrumentation/external/couchbase/couchbase.test.ts
+++ b/test/instrumentation/external/couchbase/couchbase.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { strict as assert } from 'assert';
+import { beforeEach, describe, it, mock } from 'node:test';
+import { InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation';
+import { CouchbaseInstrumentation } from '../../../../src/instrumentations/external/couchbase';
+import { cleanEnvironment } from '../../../utils';
+
+function createCouchbaseModule() {
+  const tracer = { type: 'couchbase-tracer' };
+  const meter = { type: 'couchbase-meter' };
+  const topLevelResult = { type: 'top-level-cluster' };
+  const staticResult = { type: 'static-cluster' };
+  const connect = mock.fn((..._args: unknown[]) => topLevelResult);
+  const staticConnect = mock.fn((..._args: unknown[]) => staticResult);
+
+  return {
+    tracer,
+    meter,
+    topLevelResult,
+    staticResult,
+    connect,
+    staticConnect,
+    module: {
+      getOTelTracer: mock.fn(() => tracer),
+      getOTelMeter: mock.fn(() => meter),
+      connect,
+      Cluster: {
+        connect: staticConnect,
+      },
+    },
+  };
+}
+
+function patchModule(
+  module: ReturnType<typeof createCouchbaseModule>['module']
+) {
+  const instrumentation = new CouchbaseInstrumentation();
+  const [definition] =
+    instrumentation.getModuleDefinitions() as InstrumentationNodeModuleDefinition[];
+  definition.patch?.(module, '4.7.0');
+  return { definition, instrumentation };
+}
+
+describe('couchbase instrumentation', () => {
+  beforeEach(cleanEnvironment);
+
+  it('supports Couchbase versions with native OpenTelemetry integration', () => {
+    const instrumentation = new CouchbaseInstrumentation();
+    const [definition] =
+      instrumentation.getModuleDefinitions() as InstrumentationNodeModuleDefinition[];
+
+    assert.equal(definition.name, 'couchbase');
+    assert.deepEqual(definition.supportedVersions, ['>=4.7.0 <5']);
+  });
+
+  it('injects the native tracer without mutating connect options', () => {
+    const fake = createCouchbaseModule();
+    const { definition } = patchModule(fake.module);
+    const callback = () => undefined;
+    const options = Object.freeze({ username: 'user' });
+
+    const result = fake.module.connect(
+      'couchbase://localhost',
+      options,
+      callback
+    );
+
+    assert.strictEqual(result, fake.topLevelResult);
+    assert.equal(fake.module.getOTelTracer.mock.callCount(), 1);
+    assert.equal(
+      fake.module.getOTelTracer.mock.calls[0].arguments.length,
+      0,
+      'Couchbase should resolve the registered global tracer provider'
+    );
+    assert.equal(fake.module.getOTelMeter.mock.callCount(), 0);
+    const call = fake.connect.mock.calls[0];
+    assert.equal(call.arguments[0], 'couchbase://localhost');
+    assert.notStrictEqual(call.arguments[1], options);
+    assert.deepEqual(call.arguments[1], {
+      username: 'user',
+      tracer: fake.tracer,
+    });
+    assert.strictEqual(call.arguments[2], callback);
+
+    definition.unpatch?.(fake.module, '4.7.0');
+  });
+
+  it('injects native metrics when instrumentation metrics are enabled', () => {
+    process.env.SPLUNK_INSTRUMENTATION_METRICS_ENABLED = 'true';
+    const fake = createCouchbaseModule();
+    const { definition } = patchModule(fake.module);
+
+    fake.module.connect('couchbase://localhost');
+
+    assert.equal(fake.module.getOTelTracer.mock.callCount(), 1);
+    assert.equal(fake.module.getOTelMeter.mock.callCount(), 1);
+    assert.equal(
+      fake.module.getOTelMeter.mock.calls[0].arguments.length,
+      0,
+      'Couchbase should resolve the registered global meter provider'
+    );
+    assert.deepEqual(fake.connect.mock.calls[0].arguments[1], {
+      tracer: fake.tracer,
+      meter: fake.meter,
+    });
+
+    definition.unpatch?.(fake.module, '4.7.0');
+  });
+
+  it('preserves explicitly configured telemetry', () => {
+    process.env.SPLUNK_INSTRUMENTATION_METRICS_ENABLED = 'true';
+    const fake = createCouchbaseModule();
+    const { definition } = patchModule(fake.module);
+    const tracer = { type: 'custom-tracer' };
+    const meter = { type: 'custom-meter' };
+    const options = { tracer, meter };
+
+    fake.module.connect('couchbase://localhost', options);
+
+    assert.equal(fake.module.getOTelTracer.mock.callCount(), 0);
+    assert.equal(fake.module.getOTelMeter.mock.callCount(), 0);
+    assert.strictEqual(fake.connect.mock.calls[0].arguments[1], options);
+
+    definition.unpatch?.(fake.module, '4.7.0');
+  });
+
+  it('respects explicit tracing and metrics disablement', () => {
+    process.env.SPLUNK_INSTRUMENTATION_METRICS_ENABLED = 'true';
+    const fake = createCouchbaseModule();
+    const { definition } = patchModule(fake.module);
+    const options = {
+      tracingConfig: { enableTracing: false },
+      metricsConfig: { enableMetrics: false },
+    };
+
+    fake.module.connect('couchbase://localhost', options);
+
+    assert.equal(fake.module.getOTelTracer.mock.callCount(), 0);
+    assert.equal(fake.module.getOTelMeter.mock.callCount(), 0);
+    assert.strictEqual(fake.connect.mock.calls[0].arguments[1], options);
+
+    definition.unpatch?.(fake.module, '4.7.0');
+  });
+
+  it('also instruments Cluster.connect', () => {
+    const fake = createCouchbaseModule();
+    const { definition } = patchModule(fake.module);
+
+    const result = fake.module.Cluster.connect('couchbase://localhost');
+
+    assert.strictEqual(result, fake.staticResult);
+    assert.deepEqual(fake.staticConnect.mock.calls[0].arguments[1], {
+      tracer: fake.tracer,
+    });
+
+    definition.unpatch?.(fake.module, '4.7.0');
+  });
+});

--- a/test/instrumentations.test.ts
+++ b/test/instrumentations.test.ts
@@ -32,7 +32,7 @@ describe('instrumentations', () => {
 
   it('loads instrumentations if they are installed', () => {
     const loadedInstrumentations = getInstrumentations();
-    assert.equal(loadedInstrumentations.length, 42);
+    assert.equal(loadedInstrumentations.length, 43);
   });
 
   it('does not load instrumentations if OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED is false', () => {
@@ -80,7 +80,7 @@ describe('instrumentations', () => {
       ),
       undefined
     );
-    assert.equal(loadedInstrumentations.length, 41);
+    assert.equal(loadedInstrumentations.length, 42);
   });
 
   describe('database trace context propagation', () => {


### PR DESCRIPTION
This adds support for CouchBase (>4.7.0) instrumentation. CouchBase supports OTel, but does not enable the OTel pipeline if a tracing or meter provider is available, instead one has to inject the tracer and meter.

This small adapter does the tracer and meter injection.